### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,9 @@ wayland_protos = dependency('wayland-protocols')
 gtkmm          = dependency('gtkmm-3.0')
 wfconfig       = dependency('wf-config') #TODO fallback submodule
 
+needs_libinotify = ['freebsd', 'dragonfly'].contains(host_machine.system())
+libinotify       = dependency('libinotify', required: needs_libinotify)
+
 add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter', '-Wno-parentheses', '-Wno-cast-function-type'], language: 'cpp')
 
 icon_dir = join_paths(get_option('prefix'), 'share', 'wayfire', 'icons')

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -1,5 +1,5 @@
 util = static_library('util', ['display.cpp', 'gtk-utils.cpp', 'wf-shell-app.cpp', 'wf-autohide-window.cpp'],
-    dependencies: [wf_protos, wayland_client, gtkmm, wfconfig])
+    dependencies: [wf_protos, wayland_client, gtkmm, wfconfig, libinotify])
 
 util_includes = include_directories('.')
 libutil = declare_dependency(


### PR DESCRIPTION
Port of https://github.com/WayfireWM/wayfire/commit/64a9bba7d941 to fix the following:
```c++
../src/util/wf-shell-app.cpp:3:10: fatal error: 'sys/inotify.h' file not found
#include <sys/inotify.h>
         ^~~~~~~~~~~~~~~
ld: error: undefined symbol: inotify_init
>>> referenced by wf-shell-app.cpp:41 (../src/util/wf-shell-app.cpp:41)
>>>               wf-shell-app.cpp.o:(WayfireShellApp::on_activate()) in archive src/util/libutil.a

ld: error: undefined symbol: inotify_add_watch
>>> referenced by wf-shell-app.cpp:21 (../src/util/wf-shell-app.cpp:21)
>>>               wf-shell-app.cpp.o:(do_reload_config(WayfireShellApp*)) in archive src/util/libutil.a
```