### PR TITLE
clock: Fix calender month

### DIFF
--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -40,7 +40,8 @@ void WayfireClock::on_calendar_shown()
 {
     auto now = Glib::DateTime::create_now_local();
 
-    calendar.select_month(now.get_month(), now.get_year());
+    /* GDateTime uses month in 1-12 format while GClender uses 0-11  */
+    calendar.select_month(now.get_month() - 1, now.get_year());
     calendar.select_day(now.get_day_of_month());
 }
 


### PR DESCRIPTION
GDateTime uses month 1-12 while GCalender uses 0-11.

Thanks to gimpnixon for pointing out the problem.