### PR TITLE
volume: disconnect all signal handlers when destroying widget

### DIFF
--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -190,6 +190,17 @@ static void notify_is_muted(GvcMixerControl *gvc_control,
     wf_volume->update_icon();
 }
 
+void WayfireVolume::disconnect_gvc_stream_signals()
+{
+    if (notify_volume_signal)
+        g_signal_handler_disconnect(gvc_stream, notify_volume_signal);
+    notify_volume_signal = 0;
+
+    if (notify_is_muted_signal)
+        g_signal_handler_disconnect(gvc_stream, notify_is_muted_signal);
+    notify_is_muted_signal = 0;
+}
+
 void WayfireVolume::on_default_sink_changed()
 {
     gvc_stream = gvc_mixer_control_get_default_sink(gvc_control);
@@ -199,15 +210,9 @@ void WayfireVolume::on_default_sink_changed()
     }
 
     /* Reconnect signals to new sink */
-    if (notify_volume_signal)
-        g_signal_handler_disconnect(gvc_stream, notify_volume_signal);
-
+    disconnect_gvc_stream_signals();
     notify_volume_signal = g_signal_connect (gvc_stream, "notify::volume",
         G_CALLBACK (notify_volume), this);
-
-    if (notify_is_muted_signal)
-        g_signal_handler_disconnect(gvc_stream, notify_is_muted_signal);
-
     notify_is_muted_signal = g_signal_connect (gvc_stream, "notify::is-muted",
         G_CALLBACK (notify_is_muted), this);
 
@@ -269,8 +274,8 @@ void WayfireVolume::init(Gtk::HBox *container)
 
     /* Setup gvc control */
     gvc_control = gvc_mixer_control_new("Wayfire Volume Control");
-    g_signal_connect (gvc_control, "default-sink-changed",
-        G_CALLBACK (default_sink_changed), this);
+    notify_default_sink_changed = g_signal_connect (gvc_control,
+        "default-sink-changed", G_CALLBACK (default_sink_changed), this);
     gvc_mixer_control_open(gvc_control);
 
     /* Setup layout */
@@ -282,4 +287,13 @@ void WayfireVolume::init(Gtk::HBox *container)
 }
 
 WayfireVolume::~WayfireVolume()
-{ }
+{
+    disconnect_gvc_stream_signals();
+
+    gvc_mixer_control_close(gvc_control);
+    g_object_unref(gvc_control);
+    if (notify_default_sink_changed)
+        g_signal_handler_disconnect(gvc_control, notify_default_sink_changed);
+
+    popover_timeout.disconnect();
+}

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -50,8 +50,10 @@ class WayfireVolume : public WayfireWidget
 
     gulong notify_volume_signal = 0;
     gulong notify_is_muted_signal = 0;
+    gulong notify_default_sink_changed = 0;
     sigc::connection popover_timeout;
     sigc::connection volume_changed_signal;
+    void disconnect_gvc_stream_signals();
 
     enum set_volume_flags_t
     {


### PR DESCRIPTION
This happens when output is unplugged or when widget is unloaded.