### PR TITLE
Make pulse dependency optional

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,6 +1,0 @@
-#ifndef CONFIG_H
-#define CONFIG_H
-
-#mesondefine HAVE_PULSE
-
-#endif /* end of include guard: CONFIG_H */

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#mesondefine HAVE_PULSE
+
+#endif /* end of include guard: CONFIG_H */

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ endif
 needs_libinotify = ['freebsd', 'dragonfly'].contains(host_machine.system())
 libinotify       = dependency('libinotify', required: needs_libinotify)
 
-add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter', '-Wno-parentheses', '-Wno-cast-function-type'], language: 'cpp')
+add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter', '-Wno-parentheses'], language: 'cpp')
 
 icon_dir = join_paths(get_option('prefix'), 'share', 'wayfire', 'icons')
 add_project_arguments('-DICONDIR="' + icon_dir + '"', language : 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
 	'cpp',
 	version: '0.3',
 	license: 'MIT',
-	meson_version: '>=0.43.0',
+	meson_version: '>=0.47.0',
 	default_options: [
 		'cpp_std=c++14',
         'c_std=c11',
@@ -18,8 +18,19 @@ wayland_protos = dependency('wayland-protocols')
 gtkmm          = dependency('gtkmm-3.0')
 wfconfig       = dependency('wf-config', version: '>=0.3') #TODO fallback submodule
 gtklayershell  = dependency('gtk-layer-shell-0', version: '>= 0.1', fallback: ['gtk-layer-shell', 'gtk_layer_shell_dep'])
-libpulse       = dependency('libpulse')
-libgvc         = subproject('gvc', default_options: ['static=true']).get_variable('libgvc_dep')
+libpulse       = dependency('libpulse', required : get_option('pulse'))
+libgvc         = subproject('gvc', default_options: ['static=true'], required : get_option('pulse'))
+
+conf_data = configuration_data()
+
+if libpulse.found()
+  libgvc = libgvc.get_variable('libgvc_dep')
+  conf_data.set('HAVE_PULSE', true)
+endif
+
+configure_file(input: 'config.h.in',
+               output: 'config.h',
+               configuration: conf_data)
 
 needs_libinotify = ['freebsd', 'dragonfly'].contains(host_machine.system())
 libinotify       = dependency('libinotify', required: needs_libinotify)

--- a/meson.build
+++ b/meson.build
@@ -21,16 +21,10 @@ gtklayershell  = dependency('gtk-layer-shell-0', version: '>= 0.1', fallback: ['
 libpulse       = dependency('libpulse', required : get_option('pulse'))
 libgvc         = subproject('gvc', default_options: ['static=true'], required : get_option('pulse'))
 
-conf_data = configuration_data()
-
 if libpulse.found()
   libgvc = libgvc.get_variable('libgvc_dep')
-  conf_data.set('HAVE_PULSE', true)
+  add_project_arguments('-DHAVE_PULSE=1', language : 'cpp')
 endif
-
-configure_file(input: 'config.h.in',
-               output: 'config.h',
-               configuration: conf_data)
 
 needs_libinotify = ['freebsd', 'dragonfly'].contains(host_machine.system())
 libinotify       = dependency('libinotify', required: needs_libinotify)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('pulse', type: 'feature', value: 'auto', description: 'Build pulseaudio volume widget')

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -4,10 +4,16 @@ widget_sources = ['widgets/battery.cpp',
                   'widgets/launchers.cpp',
                   'widgets/network.cpp',
                   'widgets/spacing.cpp',
-                  'widgets/volume.cpp',
                   'widgets/window-list/window-list.cpp',
                   'widgets/window-list/toplevel.cpp']
 
+deps = [gtkmm, wayland_client, libutil, wf_protos, wfconfig, gtklayershell]
+
+if libpulse.found()
+  widget_sources += 'widgets/volume.cpp'
+  deps += [libpulse, libgvc]
+endif
+
 executable('wf-panel', ['panel.cpp'] + widget_sources,
-        dependencies: [gtkmm, wayland_client, libutil, wf_protos, wfconfig, gtklayershell, libpulse, libgvc],
+        dependencies: deps,
         install: true)

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 
 #include <map>
+#include "../../config.h"
 
 #include "panel.hpp"
 
@@ -21,7 +22,9 @@
 #include "widgets/launchers.hpp"
 #include "widgets/network.hpp"
 #include "widgets/spacing.hpp"
+#ifdef HAVE_PULSE
 #include "widgets/volume.hpp"
+#endif
 #include "widgets/window-list/window-list.hpp"
 
 #include "wf-shell-app.hpp"
@@ -201,8 +204,10 @@ class WayfirePanel::impl
             return Widget(new WayfireNetworkInfo());
         if (name == "battery")
             return Widget(new WayfireBatteryInfo());
+#ifdef HAVE_PULSE
         if (name == "volume")
             return Widget(new WayfireVolume());
+#endif
         if (name == "window-list")
             return Widget(new WayfireWindowList(output));
 

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -23,8 +23,6 @@
 #include "widgets/spacing.hpp"
 #ifdef HAVE_PULSE
 #include "widgets/volume.hpp"
-#else
-#warning "Pulse not found, volume widget will not be available."
 #endif
 #include "widgets/window-list/window-list.hpp"
 
@@ -205,10 +203,15 @@ class WayfirePanel::impl
             return Widget(new WayfireNetworkInfo());
         if (name == "battery")
             return Widget(new WayfireBatteryInfo());
+        if (name == "volume") {
 #ifdef HAVE_PULSE
-        if (name == "volume")
             return Widget(new WayfireVolume());
+#else
+#warning "Pulse not found, volume widget will not be available."
+        std::cerr << "Built without pulse support, volume widget "
+            " is not available." << std::endl;
 #endif
+        }
         if (name == "window-list")
             return Widget(new WayfireWindowList(output));
 

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -12,7 +12,6 @@
 #include <sstream>
 
 #include <map>
-#include "../../config.h"
 
 #include "panel.hpp"
 

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -23,6 +23,8 @@
 #include "widgets/spacing.hpp"
 #ifdef HAVE_PULSE
 #include "widgets/volume.hpp"
+#else
+#warning "Pulse not found, volume widget will not be available."
 #endif
 #include "widgets/window-list/window-list.hpp"
 


### PR DESCRIPTION
This makes building gvc and volume widget optional which is needed
to build wf-shell without pulseaudio dependency.