### PR TITLE
Add path for default options file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,10 +33,12 @@ libinotify       = dependency('libinotify', required: needs_libinotify)
 add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter', '-Wno-parentheses'], language: 'cpp')
 
 metadata_dir = join_paths(wayfire.get_variable(pkgconfig: 'metadatadir'), 'wf-shell')
+sysconf_dir = wayfire.get_variable(pkgconfig: 'sysconfdir')
 
 icon_dir = join_paths(get_option('prefix'), 'share', 'wayfire', 'icons')
 add_project_arguments('-DICONDIR="' + icon_dir + '"', language : 'cpp')
 add_project_arguments('-DMETADATA_DIR="' + metadata_dir + '"', language : 'cpp')
+add_project_arguments('-DSYSCONF_DIR="' + sysconf_dir + '"', language : 'cpp')
 
 subdir('metadata')
 subdir('proto')

--- a/src/util/wf-shell-app.cpp
+++ b/src/util/wf-shell-app.cpp
@@ -76,7 +76,8 @@ void WayfireShellApp::on_activate()
 
     // setup config
     this->config = wf::config::build_configuration(
-        METADATA_DIR, "", get_config_file());
+        METADATA_DIR, SYSCONF_DIR "/wayfire/wf-shell-defaults.ini",
+        get_config_file());
 
     inotify_fd = inotify_init();
     do_reload_config(this);


### PR DESCRIPTION
This adds a check for a file at the location
$sysconfdir/wayfire/wf-shell-defaults.ini which can be used
to override defaults set in the metadata files.