### PR TITLE
wf-shell-app: use vector for build_configuration

### DIFF
--- a/src/util/wf-shell-app.cpp
+++ b/src/util/wf-shell-app.cpp
@@ -74,9 +74,11 @@ void WayfireShellApp::on_activate()
     wl_registry_add_listener(registry, &registry_listener, this);
     wl_display_roundtrip(wl_display);
 
+    std::vector<std::string> xmldirs(1, METADATA_DIR);
+
     // setup config
     this->config = wf::config::build_configuration(
-        METADATA_DIR, SYSCONF_DIR "/wayfire/wf-shell-defaults.ini",
+        xmldirs, SYSCONF_DIR "/wayfire/wf-shell-defaults.ini",
         get_config_file());
 
     inotify_fd = inotify_init();


### PR DESCRIPTION
Part 3 of https://github.com/WayfireWM/wayfire/issues/493.

The API was changed to accomodate loading metadata from a search
path.  That's not relevant to wf-shell (yet), so just pass a
single-element vector.