### PR TITLE
meson.build use own configuration directories

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,15 +32,15 @@ libinotify       = dependency('libinotify', required: needs_libinotify)
 
 add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter', '-Wno-parentheses'], language: 'cpp')
 
-metadata_dir = join_paths(wayfire.get_variable(pkgconfig: 'metadatadir'), 'wf-shell')
-sysconf_dir = wayfire.get_variable(pkgconfig: 'sysconfdir')
+resource_dir = join_paths(get_option('prefix'), 'share', 'wayfire')
+metadata_dir = join_paths(resource_dir, 'metadata', 'wf-shell')
+sysconf_dir = join_paths(get_option('prefix'), get_option('sysconfdir'))
 
 icon_dir = join_paths(get_option('prefix'), 'share', 'wayfire', 'icons')
 add_project_arguments('-DICONDIR="' + icon_dir + '"', language : 'cpp')
 add_project_arguments('-DMETADATA_DIR="' + metadata_dir + '"', language : 'cpp')
 add_project_arguments('-DSYSCONF_DIR="' + sysconf_dir + '"', language : 'cpp')
 
-resource_dir = join_paths(get_option('prefix'), 'share', 'wayfire')
 subdir('metadata')
 subdir('proto')
 subdir('data')


### PR DESCRIPTION
This allows for installing wf-shell into a prefix other than
Wayfire's, while preserving the original behaviour by default.