### PR TITLE
src/meson.build: generate wf-shell.pc

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -3,3 +3,13 @@ subdir('panel')
 subdir('background')
 subdir('dock')
 
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+  version: meson.project_version(),
+  name: meson.project_name(),
+  description: 'GTK3 shell for Wayfire',
+  variables: [
+    'metadatadir=' + metadata_dir,
+    'sysconfdir=' + sysconf_dir,
+  ],
+)


### PR DESCRIPTION
This is necessary to allow wcm to look up wf-shell's metadata and
sysconf directories, to initialize wf-shell's configuration.