### PR TITLE
Add "Fill and Crop" option for wf-background

### DIFF
--- a/metadata/background.xml.in
+++ b/metadata/background.xml.in
@@ -17,13 +17,21 @@
 		<_short>Randomize</_short>
 		<default>false</default>
 	</option>
-	<option name="fill_and_crop" type="bool">
-		<_short>Fill and Crop</_short>
-		<default>false</default>
-	</option>	
-	<option name="preserve_aspect" type="bool">
-		<_short>Preserve Aspect</_short>
-		<default>false</default>
+	<option name="fill_mode" type="string">
+		<_short>Fill mode</_short>
+		<default>fill_and_crop</default>
+		<desc>
+			<value>fill_and_crop</value>
+			<_name>Fill and Crop</_name>
+		</desc>
+		<desc>
+			<value>preserve_aspect</value>
+			<_name>Preserve Aspect</_name>
+		</desc>
+		<desc>
+			<value>stretch</value>
+			<_name>Stretch</_name>
+		</desc>
 	</option>
 	</plugin>
 </wf-shell>

--- a/metadata/background.xml.in
+++ b/metadata/background.xml.in
@@ -17,6 +17,10 @@
 		<_short>Randomize</_short>
 		<default>false</default>
 	</option>
+	<option name="fill_and_crop" type="bool">
+		<_short>Fill and Crop</_short>
+		<default>false</default>
+	</option>	
 	<option name="preserve_aspect" type="bool">
 		<_short>Preserve Aspect</_short>
 		<default>false</default>

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -72,34 +72,73 @@ WayfireBackground::create_from_file_safe(std::string path)
     int width = window.get_allocated_width() * scale;
     int height = window.get_allocated_height() * scale;
 
+    float screen_aspect_ratio = (float) width / height;
+    float image_aspect_ratio;
+
+    std::string fill_and_crop_string = "fill_and_crop";
+    std::string preserve_aspect_string = "preserve_aspect";
+    std::string stretch_string = "stretch";
+
+	enum FillMode { fill_and_crop, preserve_aspect, stretch };
+	FillMode current_mode;
+	
+    if (!fill_and_crop_string.compare(background_fill_mode))
+    {        
+    	current_mode = fill_and_crop;
+    }
+    else
+    {
+    	if (!preserve_aspect_string.compare(background_fill_mode))
+    	{
+    	    current_mode = preserve_aspect;
+    	} 
+    	else
+    	{
+            current_mode = stretch;
+        }
+    }
+    
     try {
         pbuf =
-            Gdk::Pixbuf::create_from_file(path, 
-                background_fill_and_crop ? -1 : width, height,
-                background_fill_and_crop || background_preserve_aspect);
+            Gdk::Pixbuf::create_from_file(path, width, height,
+                current_mode != stretch);
     } catch (...) {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
 
-    if (background_fill_and_crop)
-    {        
-     	offset_x = (width - pbuf->get_width()) * 0.5;
-        offset_y = (height - pbuf->get_height()) * 0.5;
+    if (current_mode == fill_and_crop) {
+	    image_aspect_ratio = (float) pbuf->get_height() / pbuf->get_width();
+		bool should_fill_width = 
+		     !((image_aspect_ratio < 1) && (screen_aspect_ratio > 1));
 
-    }
-    else
-    {
-    	if (background_preserve_aspect) 
-    	{
-    	    bool eq_width = (width == pbuf->get_width());
-            offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-            offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
-    	} 
-    	else
-    	{
-        offset_x = offset_y = 0.0;
-        }
-    }
+	    try {
+	        pbuf =
+	            Gdk::Pixbuf::create_from_file(path, 
+	                should_fill_width ? width : -1, 
+	                should_fill_width ? -1 : height, true);
+	    } catch (...) {
+	        return Glib::RefPtr<Gdk::Pixbuf>();
+	    }
+    } else
+
+	if (current_mode == stretch)
+	{
+		offset_x = offset_y = 0.0;
+	}
+	else
+	{
+		if (current_mode == preserve_aspect) 
+		{
+		    bool eq_width = (width == pbuf->get_width());
+	        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+	        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+		}
+		else
+		{
+			offset_x = (width - pbuf->get_width()) * 0.5;
+        	offset_y = (height - pbuf->get_height()) * 0.5;
+		}
+	}
 
     return pbuf;
 }
@@ -263,8 +302,7 @@ void WayfireBackground::setup_window()
     auto reset_cycle = [=] () { reset_cycle_timeout(); };
     background_image.set_callback(reset_background);
     background_randomize.set_callback(reset_background);
-    background_fill_and_crop.set_callback(reset_background);
-    background_preserve_aspect.set_callback(reset_background);
+    background_fill_mode.set_callback(reset_background);
     background_cycle_timeout.set_callback(reset_cycle);
 
     window.property_scale_factor().signal_changed().connect(

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -75,33 +75,31 @@ WayfireBackground::create_from_file_safe(std::string path)
 
     try {
         pbuf =
-            Gdk::Pixbuf::create_from_file(path, aspect_ratio * 2 * width, height,
-                background_preserve_aspect);
+            Gdk::Pixbuf::create_from_file(path, 
+                background_fill_and_crop ? aspect_ratio * 2 * width : width,
+                height, background_fill_and_crop || background_preserve_aspect);
     } catch (...) {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
 
-    if (background_preserve_aspect)
-    {
-       
-    	std::cout << "AR: " << aspect_ratio << std::endl;
-    	std::cout << "scale: " << scale << std::endl;
-
-        // bool eq_width = (width == pbuf->get_width());
-        // offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-
-        // offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+    if (background_fill_and_crop)
+    {        
      	offset_x = (width - pbuf->get_width()) * 0.5;
-
-        // offset_y = height - pbuf->get_height();
         offset_y = 0.0;
 
-        std::cout << "offset_x: " << offset_x << std::endl;
-        std::cout << "offset_y: " << offset_y << std::endl;
     }
     else
     {
+    	if (background_preserve_aspect) 
+    	{
+    	    bool eq_width = (width == pbuf->get_width());
+            offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+            offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+    	} 
+    	else
+    	{
         offset_x = offset_y = 0.0;
+        }
     }
 
     return pbuf;
@@ -266,6 +264,7 @@ void WayfireBackground::setup_window()
     auto reset_cycle = [=] () { reset_cycle_timeout(); };
     background_image.set_callback(reset_background);
     background_randomize.set_callback(reset_background);
+    background_fill_and_crop.set_callback(reset_background);
     background_preserve_aspect.set_callback(reset_background);
     background_cycle_timeout.set_callback(reset_cycle);
 

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -107,10 +107,8 @@ WayfireBackground::create_from_file_safe(std::string path)
     }
 
     if (current_mode == fill_and_crop) {
-	    image_aspect_ratio = (float) pbuf->get_height() / pbuf->get_width();
-		bool should_fill_width = 
-		     !((image_aspect_ratio < 1) && (screen_aspect_ratio > 1));
-
+	    image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
+		bool should_fill_width = (screen_aspect_ratio > image_aspect_ratio);
 	    try {
 	        pbuf =
 	            Gdk::Pixbuf::create_from_file(path, 

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -119,7 +119,7 @@ WayfireBackground::create_from_file_safe(std::string path)
 	    } catch (...) {
 	        return Glib::RefPtr<Gdk::Pixbuf>();
 	    }
-    } else
+    }
 
 	if (current_mode == stretch)
 	{

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -71,10 +71,11 @@ WayfireBackground::create_from_file_safe(std::string path)
     Glib::RefPtr<Gdk::Pixbuf> pbuf;
     int width = window.get_allocated_width() * scale;
     int height = window.get_allocated_height() * scale;
+    float aspect_ratio = (float) width / (float) height;
 
     try {
         pbuf =
-            Gdk::Pixbuf::create_from_file(path, width, height,
+            Gdk::Pixbuf::create_from_file(path, aspect_ratio * 2 * width, height,
                 background_preserve_aspect);
     } catch (...) {
         return Glib::RefPtr<Gdk::Pixbuf>();
@@ -82,9 +83,21 @@ WayfireBackground::create_from_file_safe(std::string path)
 
     if (background_preserve_aspect)
     {
-        bool eq_width = (width == pbuf->get_width());
-        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+       
+    	std::cout << "AR: " << aspect_ratio << std::endl;
+    	std::cout << "scale: " << scale << std::endl;
+
+        // bool eq_width = (width == pbuf->get_width());
+        // offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+
+        // offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+     	offset_x = (width - pbuf->get_width()) * 0.5;
+
+        // offset_y = height - pbuf->get_height();
+        offset_y = 0.0;
+
+        std::cout << "offset_x: " << offset_x << std::endl;
+        std::cout << "offset_y: " << offset_y << std::endl;
     }
     else
     {

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -71,13 +71,12 @@ WayfireBackground::create_from_file_safe(std::string path)
     Glib::RefPtr<Gdk::Pixbuf> pbuf;
     int width = window.get_allocated_width() * scale;
     int height = window.get_allocated_height() * scale;
-    float aspect_ratio = (float) width / (float) height;
 
     try {
         pbuf =
             Gdk::Pixbuf::create_from_file(path, 
-                background_fill_and_crop ? aspect_ratio * 2 * width : width,
-                height, background_fill_and_crop || background_preserve_aspect);
+                background_fill_and_crop ? -1 : width, height,
+                background_fill_and_crop || background_preserve_aspect);
     } catch (...) {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
@@ -85,7 +84,7 @@ WayfireBackground::create_from_file_safe(std::string path)
     if (background_fill_and_crop)
     {        
      	offset_x = (width - pbuf->get_width()) * 0.5;
-        offset_y = 0.0;
+        offset_y = (height - pbuf->get_height()) * 0.5;
 
     }
     else

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -57,8 +57,7 @@ class WayfireBackground
     WfOption<std::string> background_image{"background/image"};
     WfOption<int> background_cycle_timeout{"background/cycle_timeout"};
     WfOption<bool> background_randomize{"background/randomize"};
-    WfOption<bool> background_fill_and_crop{"background/fill_and_crop"};
-    WfOption<bool> background_preserve_aspect{"background/preserve_aspect"};
+    WfOption<std::string> background_fill_mode{"background/fill_mode"};
 
     Glib::RefPtr<Gdk::Pixbuf> create_from_file_safe(std::string path);
     bool background_transition_frame(int timer);

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -57,6 +57,7 @@ class WayfireBackground
     WfOption<std::string> background_image{"background/image"};
     WfOption<int> background_cycle_timeout{"background/cycle_timeout"};
     WfOption<bool> background_randomize{"background/randomize"};
+    WfOption<bool> background_fill_and_crop{"background/fill_and_crop"};
     WfOption<bool> background_preserve_aspect{"background/preserve_aspect"};
 
     Glib::RefPtr<Gdk::Pixbuf> create_from_file_safe(std::string path);

--- a/wf-shell.ini.example
+++ b/wf-shell.ini.example
@@ -3,8 +3,11 @@
 [background]
 # Full path to image or directory of images
 # image = /usr/share/wayfire/wallpaper.jpg
-# Whether to scale images or preserve background ratio
+# Whether to scale images or preserve background ratio and fit width
 preserve_aspect = 0
+# Whether to scale images or preserve background ratio and fit height and center
+# This overrides background/preserve_aspect
+fill_and_crop = 0
 # In the case of directory, timeout between changing backgrounds, in seconds
 cycle_timeout = 150
 # In the case of directory, whether or not to randomize images


### PR DESCRIPTION
This is my first time ever making a PR, sorry in advance if I messed something up!

I added an option that makes the wallpaper fit the height of the screen and crop the sides to preserve the aspect ratio. 
I haven't tested this on anything else besides a single 5:4 monitor with 16:9 and 21:9 wallpapers, but it works in that case. 

[Demo Video](https://streamable.com/0iwjmm)

I also realized while writing this that it doesn't crop vertical wallpapers correctly, making the name "Fill and Crop" somewhat misleading. I'll fix that ASAP.