### PR TITLE
Fixed issues generating client header using qtwaylandscanner

### DIFF
--- a/proto/wayfire-shell-unstable-v2.xml
+++ b/proto/wayfire-shell-unstable-v2.xml
@@ -1,4 +1,5 @@
-<protocol name="wayfire_shell">
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wayfire_shell_unstable_v2">
   <interface name="zwf_shell_manager_v2" version="1">
     <description summary="DE integration">
       This protocol provides additional events and requests for special DE


### PR DESCRIPTION
Renaming protocol name to `wayfire_shell_unstable_v2` fixed the include issue of qtwaylandscanner.