### PR TITLE
build: Make wayland-logout installation optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,9 @@ gtklayershell  = dependency('gtk-layer-shell-0', version: '>= 0.1', fallback: ['
 libpulse       = dependency('libpulse', required : get_option('pulse'))
 libgvc         = subproject('gvc', default_options: ['static=true'], required : get_option('pulse'))
 
-wayland_logout = subproject('wayland-logout')
+if get_option('wayland-logout') == true
+  wayland_logout = subproject('wayland-logout')
+endif
 
 if libpulse.found()
   libgvc = libgvc.get_variable('libgvc_dep')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('pulse', type: 'feature', value: 'auto', description: 'Build pulseaudio volume widget')
+option('wayland-logout', type: 'boolean', value: 'true', description: 'Install wayland-logout')


### PR DESCRIPTION
If a packager has packaged wayland-logout separately, the
wayland-logout subproject will cause wf-shell to conflict.