### PR TITLE
reload menu items when a new .desktop entry is created

### DIFF
--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -224,6 +224,11 @@ bool WayfireMenu::on_sort(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b)
 void WayfireMenu::on_popover_shown()
 {
     flowbox.unselect_all();
+    for (auto* child : flowbox.get_children())
+ 		{flowbox.remove(*child);}
+	loaded_apps.clear();
+	load_menu_items_all();
+	update_popover_layout();
 }
 
 bool WayfireMenu::update_icon()
@@ -337,9 +342,6 @@ void WayfireMenu::init(Gtk::HBox *container)
     hbox_bottom.pack_end(logout_button, false, false);
     popover_layout_box.pack_end(hbox_bottom);
     popover_layout_box.pack_end(separator);
-
-    load_menu_items_all();
-    update_popover_layout();
 
     hbox.show();
     main_image.show();

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -225,10 +225,10 @@ void WayfireMenu::on_popover_shown()
 {
     flowbox.unselect_all();
     for (auto* child : flowbox.get_children())
- 		{flowbox.remove(*child);}
-	loaded_apps.clear();
-	load_menu_items_all();
-	update_popover_layout();
+ 	{flowbox.remove(*child);}
+    loaded_apps.clear();
+    load_menu_items_all();
+    update_popover_layout();
 }
 
 bool WayfireMenu::update_icon()


### PR DESCRIPTION
Instead of having to restart wf-panel to show new menu entries, now it is done every time menu is opened.
This should make much better user experience since now i do not have to log out/ kill wf-panel every time i  install a new app.
Also closes #34