### PR TITLE
Add {panel,dock}/css_path and custom CSS support

### DIFF
--- a/metadata/dock.xml
+++ b/metadata/dock.xml
@@ -3,6 +3,10 @@
 	<plugin name="dock">
 	<_short>Dock</_short>
 	<category>Shell</category>
+	<option name="css_path" type="string">
+		<_short>CSS Path</_short>
+		<default></default>
+	</option>
 	<option name="autohide_duration" type="int">
 		<default>300</default>
 	</option>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -5,6 +5,10 @@
 	<category>Shell</category>
 	<group>
 	<_short>General</_short>
+	<option name="css_path" type="string">
+		<_short>CSS Path</_short>
+		<default></default>
+	</option>
 	<option name="widgets_left" type="string">
 		<_short>Widgets Left</_short>
 		<default>spacing4 menu spacing18 launchers</default>

--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -11,6 +11,7 @@
 #include <wf-autohide-window.hpp>
 
 #include "dock.hpp"
+#include "../util/gtk-utils.hpp"
 
 class WfDock::impl
 {
@@ -19,6 +20,8 @@ class WfDock::impl
     wl_surface *_wl_surface;
 
     Gtk::HBox box;
+
+    WfOption<std::string> css_path{"dock/css_path"};
 
     public:
     impl(WayfireOutput *output)
@@ -34,6 +37,19 @@ class WfDock::impl
         window->signal_size_allocate().connect_notify(
             sigc::mem_fun(this, &WfDock::impl::on_allocation));
         window->add(box);
+
+        if ((std::string)css_path != "")
+        {
+            auto css = load_css_from_path(css_path);
+            if (css)
+            {
+                auto screen = Gdk::Screen::get_default();
+                auto style_context = Gtk::StyleContext::create();
+                style_context->add_provider_for_screen(
+                    screen, css, GTK_STYLE_PROVIDER_PRIORITY_USER);
+            }
+        }
+
         window->show_all();
         _wl_surface = gdk_wayland_window_get_wl_surface(
             window->get_window()->gobj());

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -13,6 +13,7 @@
 #include <map>
 
 #include "panel.hpp"
+#include "../util/gtk-utils.hpp"
 
 #include "widgets/battery.hpp"
 #include "widgets/menu.hpp"
@@ -131,6 +132,7 @@ class WayfirePanel::impl
     };
 
     WfOption<int> minimal_panel_height{"panel/minimal_height"};
+    WfOption<std::string> css_path{"panel/css_path"};
 
     void create_window()
     {
@@ -147,6 +149,18 @@ class WayfirePanel::impl
 
         autohide_opt.set_callback(autohide_opt_updated);
         autohide_opt_updated(); // set initial autohide status
+
+        if ((std::string)css_path != "")
+        {
+            auto css = load_css_from_path(css_path);
+            if (css)
+            {
+                auto screen = Gdk::Screen::get_default();
+                auto style_context = Gtk::StyleContext::create();
+                style_context->add_provider_for_screen(
+                    screen, css, GTK_STYLE_PROVIDER_PRIORITY_USER);
+            }
+        }
 
         window->show_all();
         init_widgets();

--- a/src/util/gtk-utils.cpp
+++ b/src/util/gtk-utils.cpp
@@ -28,6 +28,26 @@ Glib::RefPtr<Gdk::Pixbuf> load_icon_pixbuf_safe(std::string icon_path, int size)
     }
 }
 
+Glib::RefPtr<Gtk::CssProvider> load_css_from_path(std::string path)
+{
+    try
+    {
+        auto css = Gtk::CssProvider::create();
+        css->load_from_path(path);
+        return css;
+    }
+    catch(Glib::Error& err)
+    {
+        std::cerr << "Failed to load CSS: " << err.what() << std::endl;
+        return {};
+    }
+    catch(...)
+    {
+        std::cerr << "Failed to load CSS at: " << path << std::endl;
+        return {};
+    }
+}
+
 void invert_pixbuf(Glib::RefPtr<Gdk::Pixbuf>& pbuff)
 {
     int channels = pbuff->get_n_channels();

--- a/src/util/gtk-utils.hpp
+++ b/src/util/gtk-utils.hpp
@@ -2,10 +2,14 @@
 #define WF_GTK_UTILS
 
 #include <gtkmm/image.h>
+#include <gtkmm/cssprovider.h>
 #include <string>
 
 /* Loads a pixbuf with the given size from the given file, returns null if unsuccessful */
 Glib::RefPtr<Gdk::Pixbuf> load_icon_pixbuf_safe(std::string icon_path, int size);
+
+/* Loads a CssProvider from the given path to the file, returns null if unsuccessful*/
+Glib::RefPtr<Gtk::CssProvider> load_css_from_path(std::string path);
 
 struct WfIconLoadOptions
 {


### PR DESCRIPTION
This pull request adds `panel/css_path` and `dock/css_path` into the configuration file schema, allowing for custom CSS loading of both the panel and the dock.

```ini
[panel]
css_path = /path/to.css

[dock]
css_path = /path/to.css
```

I think the code to load those CSS could've been better placed elsewhere, but I really can't be bothered to set up my editor environment again, so I would kindly ask you the maintainers to do that, as you know the project more than I do.