### PR TITLE
Added custom onclick command support to network widget.

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -161,6 +161,10 @@
 		<_short>Network Status Use Color</_short>
 		<default>false</default>
 	</option>
+	<option name="network_onclick_command" type="string">
+		<_short>On Click Command</_short>
+		<default>default</default>
+	</option>
 	</group>
 	<group>
 	<_short>Menu</_short>

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -348,7 +348,14 @@ bool WayfireNetworkInfo::setup_dbus()
 
 void WayfireNetworkInfo::on_click()
 {
-    info->spawn_control_center(nm_proxy);
+    if ((std::string)click_command_opt != "default")
+    {
+        Glib::spawn_command_line_async((std::string)click_command_opt);
+    }
+    else
+    {
+        info->spawn_control_center(nm_proxy);
+    }
 }
 
 void WayfireNetworkInfo::init(Gtk::HBox *container)

--- a/src/panel/widgets/network.hpp
+++ b/src/panel/widgets/network.hpp
@@ -64,6 +64,7 @@ class WayfireNetworkInfo : public WayfireWidget
     WfOption<bool> icon_invert_opt{"panel/network_icon_invert_color"};
     WfOption<bool> status_color_opt{"panel/network_status_use_color"};
     WfOption<std::string> status_font_opt{"panel/network_status_font"};
+    WfOption<std::string> click_command_opt{"panel/network_onclick_command"};
 
     bool setup_dbus();
     void update_active_connection();


### PR DESCRIPTION
This option allows a user to define a custom onclick command for the network widget so commands like `terminal -e nmtui` or others can be used in place of having a static dependency on gnome-control-center.