### PR TITLE
Dock size

### DIFF
--- a/metadata/dock.xml
+++ b/metadata/dock.xml
@@ -22,5 +22,13 @@
 			<_name>Bottom</_name>
 		</desc>
 	</option>
+	<option name="dock_height" type="int">
+		<_short>Dock height</_short>
+		<default>100</default>
+	</option>
+	<option name="icon_height" type="int">
+		<_short>Dock icons height</_short>
+		<default>72</default>
+	</option>
 	</plugin>
 </wf-shell>

--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -22,6 +22,7 @@ class WfDock::impl
     Gtk::HBox box;
 
     WfOption<std::string> css_path{"dock/css_path"};
+    WfOption<int> dock_height{"dock/dock_height"};
 
     public:
     impl(WayfireOutput *output)
@@ -30,7 +31,7 @@ class WfDock::impl
         window = std::unique_ptr<WayfireAutohidingWindow> (
             new WayfireAutohidingWindow(output, "dock"));
 
-        window->set_size_request(100, 100);
+        window->set_size_request(dock_height, dock_height);
         gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_TOP);
         window->increase_autohide();
 

--- a/src/dock/toplevel-icon.cpp
+++ b/src/dock/toplevel-icon.cpp
@@ -92,10 +92,9 @@ class WfToplevelIcon::impl
     {
         this->app_id = app_id;
         IconProvider::set_image_from_icon(image,
-					  app_id,
-					  icon_height,
-					  button.get_scale_factor());
-
+                                          app_id,
+                                          icon_height,
+                                          button.get_scale_factor());
     }
 
     void send_rectangle_hint()

--- a/src/dock/toplevel-icon.cpp
+++ b/src/dock/toplevel-icon.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <cassert>
+#include "wf-option-wrap.hpp"
 
 namespace IconProvider
 {
@@ -32,6 +33,7 @@ class WfToplevelIcon::impl
     Gtk::Button button;
     Gtk::Image image;
     std::string app_id;
+    WfOption<int> icon_height{"dock/icon_height"};
 
     public:
     impl(zwlr_foreign_toplevel_handle_v1 *handle, wl_output *output)
@@ -89,8 +91,10 @@ class WfToplevelIcon::impl
     void set_app_id(std::string app_id)
     {
         this->app_id = app_id;
-        IconProvider::set_image_from_icon(image, app_id,
-            72, button.get_scale_factor());
+        IconProvider::set_image_from_icon(image,
+					  app_id,
+					  icon_height,
+					  button.get_scale_factor());
 
     }
 


### PR DESCRIPTION
Hi,

This PR adds _dock_height_ and _icon_height_ to dock section options to allow the user to modify the default values:

`[dock]`
`autohide_duration = 250`
`css_path =  /home/pacomod/.config/wf-shell/wf-dock.css`
`position = bottom`
`dock_height = 50`
`icon_height = 32`

It should answer the issue #85.

