### PR TITLE
Fix volume icon muted at startup

### DIFF
--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -34,7 +34,7 @@ void WayfireVolumeScale::set_target_value(double value)
 
 double WayfireVolumeScale::get_target_value() const
 {
-    return this->current_volume;
+    return this->current_volume.end;
 }
 
 void WayfireVolumeScale::set_user_changed_callback(


### PR DESCRIPTION
During startup, the volume icon is shown as "muted", no matter whether the volume is really at 0 or at maximum value. The problem seems to be that volume_scale.get_target_value() returns the current value, not the desired one.

This patch fixes this by adding a new method that returns the set value instead of the current one. Tried to return in get_target_value() the final value instead of the current one, but breaks changing the volume.