### PR TITLE
Remove gap to the left of the menu, reduce gap to the right

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -11,7 +11,7 @@
 	</option>
 	<option name="widgets_left" type="string">
 		<_short>Widgets Left</_short>
-		<default>spacing4 menu spacing18 launchers window-list</default>
+		<default>menu spacing4 launchers window-list</default>
 	</option>
 	<option name="widgets_center" type="string">
 		<_short>Widgets Center</_short>

--- a/wf-shell.ini.example
+++ b/wf-shell.ini.example
@@ -17,7 +17,7 @@ randomize = 0
 # A special widgets is spacing widgets, it can be used to add padding everywhere on the panel
 # To use it, just append the amount of pixels you want as a padding
 # to the word "spacing" and use it as a plugin
-widgets_left = spacing4 menu spacing18 launchers window-list
+widgets_left = menu spacing4 launchers window-list
 widgets_center = none
 widgets_right = volume network battery clock
 


### PR DESCRIPTION
Due to [Fitts's law](https://en.wikipedia.org/wiki/Fitts%27s_law#Implications_for_UI_design), controls located on screen edges and corners are easier to move a mouse cursor over, because they act like infinitely sized regions you can't overshoot. Currently the system menu is located on the top edge of the screen, but there's a gap to the left, requiring precise mouse movement to locate the menu horizontally (overshooting and clicking does nothing, and I don't think there's a *benefit* to making it do nothing). Many other operating systems locate menus in the exact corners of screens to make them easier to locate.

I've removed the space to the left of the menu in wf-shell's default configuration.

Not sure about the optimal space to the right. I feel that removing spacing altogether feels cramped, and spacing4 feels a bit narrow, but spacing8 feels too wide. If you want, you could leave spacing18 unchanged.