### PR TITLE
Allow changing the minimum height and width for the menu.

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -180,10 +180,12 @@
 	<option name="menu_min_content_width" type="int">
 		<_short>Menu Minimum Content Width</_short>
 		<default>500</default>
+		<min>100</min>
 	</option>
 	<option name="menu_min_content_height" type="int">
 		<_short>Menu Minimum Content Height</_short>
 		<default>500</default>
+		<min>100</min>
 	</option>
 	<option name="menu_logout_command" type="string">
 		<_short>Menu Logout Command</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -177,6 +177,14 @@
 		<hint>file</hint>
 		<default></default>
 	</option>
+	<option name="menu_min_content_width" type="int">
+		<_short>Menu minimum content width</_short>
+		<default>500</default>
+	</option>
+	<option name="menu_min_content_height" type="int">
+		<_short>Menu minimum content height</_short>
+		<default>500</default>
+	</option>
 	<option name="menu_logout_command" type="string">
 		<_short>Menu Logout Command</_short>
 		<_long>If not specified, a default logout interface will be used.</_long>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -181,11 +181,13 @@
 		<_short>Menu Minimum Content Width</_short>
 		<default>500</default>
 		<min>100</min>
+		<max>5000</max>
 	</option>
 	<option name="menu_min_content_height" type="int">
 		<_short>Menu Minimum Content Height</_short>
 		<default>500</default>
 		<min>100</min>
+		<max>5000</max>
 	</option>
 	<option name="menu_logout_command" type="string">
 		<_short>Menu Logout Command</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -178,11 +178,11 @@
 		<default></default>
 	</option>
 	<option name="menu_min_content_width" type="int">
-		<_short>Menu minimum content width</_short>
+		<_short>Menu Minimum Content Width</_short>
 		<default>500</default>
 	</option>
 	<option name="menu_min_content_height" type="int">
-		<_short>Menu minimum content height</_short>
+		<_short>Menu Minimum Content Height</_short>
 		<default>500</default>
 	</option>
 	<option name="menu_logout_command" type="string">

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -276,8 +276,8 @@ void WayfireMenu::update_popover_layout()
         flowbox_container.add(bottom_pad);
         flowbox_container.add(flowbox);
 
-        scrolled_window.set_min_content_width(500);
-        scrolled_window.set_min_content_height(500);
+        scrolled_window.set_min_content_width(int(menu_min_content_width));
+        scrolled_window.set_min_content_height(int(menu_min_content_height));
         scrolled_window.add(flowbox_container);
 
         search_box.property_margin().set_value(20);

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -116,6 +116,8 @@ class WayfireMenu : public WayfireWidget
     WfOption<std::string> panel_position{"panel/position"};
     WfOption<std::string> menu_icon{"panel/menu_icon"};
     WfOption<int> menu_size{"panel/launchers_size"};
+    WfOption<int> menu_min_content_width{"panel/menu_min_content_width"};
+    WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
     void update_popover_layout();
     void create_logout_ui();
     void on_logout_click();

--- a/wf-shell.ini.example
+++ b/wf-shell.ini.example
@@ -103,6 +103,11 @@ network_status_use_color = yes
 # whether to enable fuzzy search in the menu
 menu_fuzzy_search = 1
 
+# Minimum width and height for the contents of the menu.
+# Can be useful for small screens and/or high DPI scaling.
+menu_min_content_width = 500
+menu_min_content_height = 500
+
 # image file to use as the menu icon
 # menu_icon = /usr/share/wayfire/icons/wayfire.png
 


### PR DESCRIPTION
Recently I tried using Wayfire on my PinePhone, but I found that the menu didn't fit on the screen when using 200% DPI scaling in Wayfire. This PR allows the user to set the minimum height and width of the menu's content from Wayfire Config Manager>Panel>Menu. Not sure on the option names, but I named them "menu_min_content_height" and "menu_min_content_width" in the code, respectively, so they're similar to the "set_min_content_*" calls. They're labeled the same thing in WCM, just in Pascal Case and with spaces instead of underscores to match the other options. For the min and max values, I set them to 100 and 5000 respectively, with 100 for the minimum so the menu doesn't become too small to be usable, and 5000 so things don't crash when opening the menu. The only thing with the max value is that the menu may become too large to be usable depending on the display scaling and resolution if the user sets it too high. Not sure how to handle that. The default was set to 500 as that's what was hardcoded previously.

One thing I did notice is that the logout and search buttons are still a little large in 200% scaling, so they may take up space that the menu may need, but this PR doesn't address that and it may just be a result of using 200% on a 96 DPI display for testing.