### PR TITLE
Space between icon and label

### DIFF
--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -147,9 +147,14 @@ void WayfireBatteryInfo::update_details()
     else if (status_opt == BATTERY_STATUS_FULL)
     {
         label.set_text(description);
-    } else
+    }
+    if (status_opt == BATTERY_STATUS_ICON)
     {
-        label.set_text("");
+        label.hide();
+    }
+    else
+    {
+        label.show();
     }
 }
 
@@ -220,6 +225,7 @@ void WayfireBatteryInfo::init(Gtk::HBox *container)
 
     container->pack_start(button, Gtk::PACK_SHRINK);
     button_box.add(label);
+    button_box.set_spacing(5);
 
     button.add(button_box);
     button.property_scale_factor().signal_changed()

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -56,6 +56,7 @@ class WayfireToplevel::impl
         button_contents.add(image);
         button_contents.add(label);
         button_contents.set_halign(Gtk::ALIGN_START);
+        button_contents.set_spacing(5);
         button.add(button_contents);
         button.set_tooltip_text("none");
 


### PR DESCRIPTION
Adds spacing between icons and labels in `battery` and `window-list` widgets