### PR TITLE
refactor window-list

### DIFF
--- a/src/panel/widgets/window-list/toplevel.hpp
+++ b/src/panel/widgets/window-list/toplevel.hpp
@@ -27,7 +27,6 @@ class WayfireToplevel
     WayfireToplevel(WayfireWindowList *window_list, zwlr_foreign_toplevel_handle_v1 *handle);
 
     uint32_t get_state();
-    void set_width(int pixels);
     zwlr_foreign_toplevel_handle_v1 * get_parent();
     void set_parent(zwlr_foreign_toplevel_handle_v1 *);
     std::vector<zwlr_foreign_toplevel_handle_v1 *>& get_children();

--- a/src/panel/widgets/window-list/window-list.hpp
+++ b/src/panel/widgets/window-list/window-list.hpp
@@ -65,7 +65,6 @@ class WayfireWindowList : public WayfireWidget
     zwlr_foreign_toplevel_manager_v1 *manager;
     WayfireOutput *output;
     WayfireWindowListBox box;
-    Gtk::ScrolledWindow scrolled_window;
 
     WayfireWindowList(WayfireOutput *output);
     virtual ~WayfireWindowList();
@@ -77,14 +76,6 @@ class WayfireWindowList : public WayfireWidget
     wayfire_config *get_config();
 
     void init(Gtk::HBox *container) override;
-    void add_output(WayfireOutput *output);
-
-    private:
-    void on_draw(const Cairo::RefPtr<Cairo::Context>&);
-
-    void set_button_width(int width);
-    int get_default_button_width();
-    int get_target_button_width();
 };
 
 #endif /* end of include guard: WIDGETS_WINDOW_LIST_HPP */


### PR DESCRIPTION
Probably fixes #150

This patch refactors the calculation of `WayfireToplevel`'s width. Instead of recalculating the width manually, it simply does `label.set_ellipsize` and `label.set_max_width_chars`.

Also there are a few minor style-ish changes suggested by clang-tidy.