### PR TITLE
tray: support IconThemePath property

### DIFF
--- a/src/panel/widgets/tray/item.hpp
+++ b/src/panel/widgets/tray/item.hpp
@@ -4,6 +4,7 @@
 #include <giomm.h>
 #include <gtkmm/eventbox.h>
 #include <gtkmm/hvbox.h>
+#include <gtkmm/icontheme.h>
 #include <gtkmm/image.h>
 #include <gtkmm/menu.h>
 
@@ -25,6 +26,8 @@ class StatusNotifierItem : public Gtk::EventBox
 
     gdouble distance_scrolled_x = 0;
     gdouble distance_scrolled_y = 0;
+
+    Glib::RefPtr<Gtk::IconTheme> icon_theme = Gtk::IconTheme::get_default();
 
     template <typename T>
     T get_item_property(const Glib::ustring &name, const T &default_value = {}) const

--- a/src/util/gtk-utils.cpp
+++ b/src/util/gtk-utils.cpp
@@ -79,9 +79,9 @@ void set_image_pixbuf(Gtk::Image &image, Glib::RefPtr<Gdk::Pixbuf> pixbuf, int s
 }
 
 void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
-                    const WfIconLoadOptions& options)
+                    const WfIconLoadOptions& options,
+                    const Glib::RefPtr<Gtk::IconTheme>& icon_theme)
 {
-    auto icon_theme = Gtk::IconTheme::get_default();
     int scale = ((options.user_scale == -1) ?
                  image.get_scale_factor() : options.user_scale);
     int scaled_size = size * scale;

--- a/src/util/gtk-utils.hpp
+++ b/src/util/gtk-utils.hpp
@@ -2,6 +2,7 @@
 #define WF_GTK_UTILS
 
 #include <gtkmm/image.h>
+#include <gtkmm/icontheme.h>
 #include <gtkmm/cssprovider.h>
 #include <string>
 
@@ -23,7 +24,9 @@ void set_image_pixbuf(Gtk::Image &image, Glib::RefPtr<Gdk::Pixbuf> pixbuf, int s
 /* Sets the content of the image to the corresponding icon from the default theme,
  * using the given options */
 void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
-                    const WfIconLoadOptions& options);
+                    const WfIconLoadOptions& options,
+                    const Glib::RefPtr<Gtk::IconTheme>& icon_theme
+                        = Gtk::IconTheme::get_default());
 
 void invert_pixbuf(Glib::RefPtr<Gdk::Pixbuf>& pbuff);
 


### PR DESCRIPTION
`IconThemePath` is `libappindicator`'s non-standardized property of `StatusNotifierItem`. In particular, it's used by Steam, so I think it should be supported by `wf-panel`'s implementation of SNI as well.