### PR TITLE
icon size option for volume and notifications

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -124,7 +124,8 @@
 	</option>
 	<option name="battery_icon_size" type="int">
 		<_short>Battery Icon Size</_short>
-		<default>24</default>
+		<default>32</default>
+		<min>1</min>
 	</option>
 	<option name="battery_icon_invert" type="bool">
 		<_short>Battery Icon Invert Color</_short>
@@ -162,6 +163,7 @@
 	<option name="network_icon_size" type="int">
 		<_short>Network Icon Size</_short>
 		<default>32</default>
+		<min>1</min>
 	</option>
 	<option name="network_icon_invert_color" type="bool">
 		<_short>Network Icon Invert Color</_short>
@@ -235,6 +237,11 @@
 		<_short>Volume Display Timeout</_short>
 		<default>2.5</default>
 	</option>
+	<option name="volume_icon_size" type="int">
+		<_short>Volume Icon Size</_short>
+		<default>32</default>
+		<min>1</min>
+	</option>
 	</group>
 	<group>
 	<_short>Notifications</_short>
@@ -247,6 +254,11 @@
 		<_short>Always Show Critical notifications</_short>
 		<_long>Makes critical notifications to be shown even in DND mode.</_long>
 		<default>true</default>
+	</option>
+	<option name="notifications_icon_size" type="int">
+		<_short>Notifications Icon Size</_short>
+		<default>32</default>
+		<min>1</min>
 	</option>
 	</group>
 	<group>

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -2,6 +2,8 @@
 
 #include <glibmm/main.h>
 
+#include <gtk-utils.hpp>
+
 #include "daemon.hpp"
 #include "single-notification.hpp"
 
@@ -103,7 +105,7 @@ void WayfireNotificationCenter::onDaemonStop()
 void WayfireNotificationCenter::updateIcon()
 {
     if (dnd_enabled)
-        icon.set_from_icon_name("notifications-disabled", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        set_image_icon(icon, "notifications-disabled", icon_size);
     else
-        icon.set_from_icon_name("notifications", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        set_image_icon(icon, "notifications", icon_size);
 }

--- a/src/panel/widgets/notifications/notification-center.hpp
+++ b/src/panel/widgets/notifications/notification-center.hpp
@@ -28,6 +28,7 @@ class WayfireNotificationCenter : public WayfireWidget
     sigc::connection popover_timeout;
     WfOption<double> timeout{"panel/notifications_autohide_timeout"};
     WfOption<bool> show_critical_in_dnd{"panel/notifications_critical_in_dnd"};
+    WfOption<int> icon_size{"panel/notifications_icon_size"};
     bool dnd_enabled = false;
 
     public:

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -73,7 +73,7 @@ void WayfireVolume::update_icon()
 
     if (gvc_stream && gvc_mixer_stream_get_is_muted(gvc_stream))
     {
-        main_image.set_from_icon_name("audio-volume-muted", Gtk::ICON_SIZE_MENU);
+        set_image_icon(main_image, "audio-volume-muted", icon_size);
         return;
     }
 
@@ -85,9 +85,7 @@ void WayfireVolume::update_icon()
         {VOLUME_LEVEL_OOR, "audio-volume-muted"},
     };
 
-    button->set_size_request(0, 0);
-    main_image.set_from_icon_name(icon_name_from_state[current],
-        Gtk::ICON_SIZE_MENU);
+    set_image_icon(main_image, icon_name_from_state.at(current), icon_size);
 }
 
 bool WayfireVolume::on_popover_timeout(int timer)
@@ -244,7 +242,7 @@ void WayfireVolume::on_volume_value_changed()
 
 void WayfireVolume::init(Gtk::HBox *container)
 {
-    volume_size.set_callback([=] () { update_icon(); });
+    icon_size.set_callback([=] () { update_icon(); });
 
     /* Setup button */
     button = std::make_unique<WayfireMenuButton> ("panel");

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -36,7 +36,7 @@ class WayfireVolume : public WayfireWidget
     WayfireVolumeScale volume_scale;
     std::unique_ptr<WayfireMenuButton> button;
 
-    WfOption<int> volume_size{"panel/launchers_size"};
+    WfOption<int> icon_size{"panel/volume_icon_size"};
     WfOption<double> timeout{"panel/volume_display_timeout"};
 
     void on_volume_scroll(GdkEventScroll *event);

--- a/src/util/gtk-utils.cpp
+++ b/src/util/gtk-utils.cpp
@@ -92,7 +92,7 @@ void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
         return;
     }
 
-    auto pbuff = icon_theme->load_icon(icon_name, scaled_size)
+    auto pbuff = icon_theme->load_icon(icon_name, scaled_size, Gtk::ICON_LOOKUP_FORCE_SIZE)
         ->scale_simple(scaled_size, scaled_size, Gdk::INTERP_BILINEAR);
 
     if (options.invert)

--- a/src/util/gtk-utils.hpp
+++ b/src/util/gtk-utils.hpp
@@ -24,7 +24,7 @@ void set_image_pixbuf(Gtk::Image &image, Glib::RefPtr<Gdk::Pixbuf> pixbuf, int s
 /* Sets the content of the image to the corresponding icon from the default theme,
  * using the given options */
 void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
-                    const WfIconLoadOptions& options,
+                    const WfIconLoadOptions& options = {},
                     const Glib::RefPtr<Gtk::IconTheme>& icon_theme
                         = Gtk::IconTheme::get_default());
 


### PR DESCRIPTION
 - Adds icon size option for `volume` and `notifications` widgets
 - Changes `battery_icon_size`'s default value to `32`
 - Adds missing `*_icon_size`'s min value 