### PR TITLE
Notifications: make daemon a singleton

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -260,6 +260,7 @@ class WayfirePanel::impl
         Gtk::HBox& box)
     {
         const auto lock_sn_watcher = Watcher::Instance();
+        const auto lock_notification_daemon = Daemon::Instance();
         container.clear();
         auto widgets = tokenize(list);
         for (auto widget_name : widgets)

--- a/src/panel/widgets/notifications/daemon.cpp
+++ b/src/panel/widgets/notifications/daemon.cpp
@@ -9,10 +9,6 @@
 #define FDN_PATH "/org/freedesktop/Notifications"
 #define FDN_NAME "org.freedesktop.Notifications"
 
-namespace Daemon
-{
-static std::map<Notification::id_type, const Notification> notifications;
-
 const auto introspection_data =
     Gio::DBus::NodeInfo::create_for_xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                                         "<node name=\"" FDN_PATH "\">"
@@ -58,67 +54,23 @@ const auto introspection_data =
                                                                                                    "</node>")
     ->lookup_interface();
 
-bool is_running = false;
-guint owner_id  = 0;
-
-// used to emit dbus signals
-Glib::RefPtr<Gio::DBus::Connection> connection;
-
-notification_signal signal_notification_new;
-notification_signal signal_notification_replaced;
-notification_signal signal_notification_closed;
-
-notification_signal signalNotificationNew()
-{
-    return signal_notification_new;
-}
-
-notification_signal signalNotificationReplaced()
-{
-    return signal_notification_replaced;
-}
-
-notification_signal signalNotificationClosed()
-{
-    return signal_notification_closed;
-}
-
-sigc::signal<void> signal_daemon_stopped;
-
-sigc::signal<void> signalDaemonStopped()
-{
-    return signal_daemon_stopped;
-}
-
-using DBusMethod =
-    void (*)(const Glib::RefPtr<Gio::DBus::Connection> & connection, const Glib::ustring & sender,
-        const Glib::VariantContainerBase & parameters,
-        const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation);
-
-#define dbus_method(name)                                                                                              \
-    static void dbusMethod ## name(const Glib::RefPtr<Gio::DBus::Connection> & connection, \
-    const Glib::ustring & sender,   \
-    const Glib::VariantContainerBase & parameters,                                         \
-    const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation)
-
-dbus_method(GetCapabilities)
+dbus_method(Daemon::GetCapabilities)
 {
     static const auto value = Glib::Variant<std::tuple<std::vector<Glib::ustring>>>::create(
         {{"action-icons", "actions", "body", "body-hyperlinks", "body-markup", "body-images",
             "persistance"}});
     invocation->return_value(value);
-    connection->flush();
 }
 
-dbus_method(Notify)
-try {
+dbus_method(Daemon::Notify)
+try
+{
     const auto notification = Notification(parameters, sender);
     const auto id     = notification.id;
     const auto id_var =
         Glib::VariantContainerBase::create_tuple(Glib::Variant<Notification::id_type>::create(id));
 
     invocation->return_value(id_var);
-    connection->flush();
 
     bool is_replacing = notifications.count(id) == 1;
     if (is_replacing)
@@ -140,97 +92,81 @@ try {
     std::cerr << "Error at " << __PRETTY_FUNCTION__ << ": " << err.what() << std::endl;
 }
 
-dbus_method(CloseNotification)
+dbus_method(Daemon::CloseNotification)
 {
     Glib::VariantBase id_var;
     parameters.get_child(id_var, 0);
     invocation->return_value(Glib::VariantContainerBase());
-    closeNotification(Glib::VariantBase::cast_dynamic<Glib::Variant<Notification::id_type>>(id_var).get(),
-        CloseReason::MethodCalled);
+    Daemon::Instance()->closeNotification(
+        Glib::VariantBase::cast_dynamic<Glib::Variant<Notification::id_type>>(id_var).get(),
+        Daemon::CloseReason::MethodCalled);
 }
 
-dbus_method(GetServerInformation)
+dbus_method(Daemon::GetServerInformation)
 {
     static const auto info =
         Glib::Variant<std::tuple<Glib::ustring, Glib::ustring, Glib::ustring, Glib::ustring>>::create(
             {"wf-panel", "wayfire.org", "0.8.0", "1.2"});
     invocation->return_value(info);
-    connection->flush();
 }
 
-#undef dbus_method
-
-void on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> & connection,
-    const Glib::ustring & sender,
-    const Glib::ustring & object_path, const Glib::ustring & interface_name,
-    const Glib::ustring & method_name, const Glib::VariantContainerBase & parameters,
-    const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation)
+void Daemon::on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection,
+                                      const Glib::ustring &sender, const Glib::ustring &object_path,
+                                      const Glib::ustring &interface_name, const Glib::ustring &method_name,
+                                      const Glib::VariantContainerBase &parameters,
+                                      const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation)
 {
-#define DBUS_METHOD_PAIR(name)                                                                                         \
-    {                                                                                                                  \
-        #name, dbusMethod ## name                                                                                        \
-    }
 
-    static const std::map<Glib::ustring, DBusMethod> methods = {
-        DBUS_METHOD_PAIR(GetCapabilities), DBUS_METHOD_PAIR(Notify), DBUS_METHOD_PAIR(CloseNotification),
-        DBUS_METHOD_PAIR(GetServerInformation)};
+#define try_invoke_method(_name)                                                                                       \
+    if (method_name == #_name)                                                                                         \
+    _name##dbus_method(sender, parameters, invocation)
 
-#undef DBUS_METHOD_PAIR
+    try_invoke_method(GetCapabilities);
+    try_invoke_method(Notify);
+    try_invoke_method(CloseNotification);
+    try_invoke_method(GetServerInformation);
+}
 
-    if (methods.count(method_name) != 0)
+void Daemon::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &name)
+{
+    object_id = connection->register_object(FDN_PATH, introspection_data, interface_vtable);
+    daemon_connection = connection;
+}
+
+std::shared_ptr<Daemon> Daemon::Launch()
+{
+    if (instance.expired())
     {
-        methods.at(method_name)(connection, sender, parameters, invocation);
-    } else
-    {
-        std::cerr << "Notifications: Error: no such method " << method_name << "\n";
+        auto new_instance = std::shared_ptr<Daemon>(new Daemon());
+        instance = new_instance;
+        return new_instance;
     }
+    return Instance();
 }
 
-const auto interface_vtable = Gio::DBus::InterfaceVTable(&on_interface_method_call);
-
-void on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection, const Glib::ustring & name)
+std::shared_ptr<Daemon> Daemon::Instance()
 {
-    connection->register_object(FDN_PATH, introspection_data, interface_vtable);
+    return instance.lock();
 }
 
-void on_name_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection, const Glib::ustring & name)
+Daemon::Daemon()
+    : owner_id(Gio::DBus::own_name(Gio::DBus::BUS_TYPE_SESSION, FDN_NAME, sigc::mem_fun(this, &Daemon::on_bus_acquired),
+                                   {}, {}, Gio::DBus::BUS_NAME_OWNER_FLAGS_REPLACE))
 {
-    if (name == FDN_NAME)
-    {
-        Daemon::connection = connection;
-    }
 }
 
-void on_name_lost(const Glib::RefPtr<Gio::DBus::Connection> & connection, const Glib::ustring & name)
+Daemon::~Daemon()
 {
-    std::cerr << "Notifications: Error: DBus connection name has been lost.\n";
-    stop();
-}
-
-void start()
-{
-    if (owner_id == 0)
-    {
-        owner_id = Gio::DBus::own_name(Gio::DBus::BUS_TYPE_SESSION, FDN_NAME, &on_bus_acquired,
-            &on_name_acquired,
-            &on_name_lost, Gio::DBus::BUS_NAME_OWNER_FLAGS_NONE);
-    }
-}
-
-void stop()
-{
-    signal_daemon_stopped.emit();
+    daemon_connection->unregister_object(object_id);
     Gio::DBus::unown_name(owner_id);
-    owner_id = 0;
-    notifications.clear();
 }
 
-const std::map<Notification::id_type, const Notification> & getNotifications()
+const std::map<Notification::id_type, const Notification> &Daemon::getNotifications() const
 {
     return notifications;
 }
 
-void closeNotification(Notification::id_type id, CloseReason reason)
+void Daemon::closeNotification(Notification::id_type id, CloseReason reason)
 {
     if (notifications.count(id) == 0)
     {
@@ -238,27 +174,19 @@ void closeNotification(Notification::id_type id, CloseReason reason)
     }
 
     signal_notification_closed.emit(id);
-    const auto & notification = notifications.at(id);
-    if (connection)
-    {
-        auto body = Glib::Variant<std::tuple<guint32, guint32>>::create({id, reason});
-        connection->emit_signal(FDN_PATH, FDN_NAME, "NotificationClosed", notification.additional_info.sender,
-            body);
-    }
+    const auto &notification = notifications.at(id);
+    const auto body = Glib::Variant<std::tuple<guint32, guint32>>::create({id, reason});
+    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "NotificationClosed", notification.additional_info.sender, body);
 }
 
-void invokeAction(Notification::id_type id, const Glib::ustring & action_key)
+void Daemon::invokeAction(Notification::id_type id, const Glib::ustring &action_key)
 {
     if (notifications.count(id) == 0)
     {
         return;
     }
 
-    if (connection)
-    {
-        auto body = Glib::Variant<std::tuple<guint32, Glib::ustring>>::create({id, action_key});
-        connection->emit_signal(FDN_PATH, FDN_NAME, "ActionInvoked", notifications.at(
-            id).additional_info.sender, body);
-    }
+    const auto body = Glib::Variant<std::tuple<guint32, Glib::ustring>>::create({id, action_key});
+    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "ActionInvoked", notifications.at(id).additional_info.sender,
+                                   body);
 }
-} // namespace Daemon

--- a/src/panel/widgets/notifications/daemon.cpp
+++ b/src/panel/widgets/notifications/daemon.cpp
@@ -63,8 +63,7 @@ dbus_method(Daemon::GetCapabilities)
 }
 
 dbus_method(Daemon::Notify)
-try
-{
+try {
     const auto notification = Notification(parameters, sender);
     const auto id     = notification.id;
     const auto id_var =
@@ -110,16 +109,15 @@ dbus_method(Daemon::GetServerInformation)
     invocation->return_value(info);
 }
 
-void Daemon::on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection,
-                                      const Glib::ustring &sender, const Glib::ustring &object_path,
-                                      const Glib::ustring &interface_name, const Glib::ustring &method_name,
-                                      const Glib::VariantContainerBase &parameters,
-                                      const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation)
+void Daemon::on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> & connection,
+    const Glib::ustring & sender, const Glib::ustring & object_path,
+    const Glib::ustring & interface_name, const Glib::ustring & method_name,
+    const Glib::VariantContainerBase & parameters,
+    const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation)
 {
-
 #define try_invoke_method(_name)                                                                                       \
     if (method_name == #_name)                                                                                         \
-    _name##dbus_method(sender, parameters, invocation)
+    _name ## dbus_method(sender, parameters, invocation)
 
     try_invoke_method(GetCapabilities);
     try_invoke_method(Notify);
@@ -127,7 +125,8 @@ void Daemon::on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> 
     try_invoke_method(GetServerInformation);
 }
 
-void Daemon::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &name)
+void Daemon::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection,
+    const Glib::ustring & name)
 {
     object_id = connection->register_object(FDN_PATH, introspection_data, interface_vtable);
     daemon_connection = connection;
@@ -141,6 +140,7 @@ std::shared_ptr<Daemon> Daemon::Launch()
         instance = new_instance;
         return new_instance;
     }
+
     return Instance();
 }
 
@@ -149,11 +149,11 @@ std::shared_ptr<Daemon> Daemon::Instance()
     return instance.lock();
 }
 
-Daemon::Daemon()
-    : owner_id(Gio::DBus::own_name(Gio::DBus::BUS_TYPE_SESSION, FDN_NAME, sigc::mem_fun(this, &Daemon::on_bus_acquired),
-                                   {}, {}, Gio::DBus::BUS_NAME_OWNER_FLAGS_REPLACE))
-{
-}
+Daemon::Daemon() :
+    owner_id(Gio::DBus::own_name(Gio::DBus::BUS_TYPE_SESSION, FDN_NAME,
+        sigc::mem_fun(this, &Daemon::on_bus_acquired),
+        {}, {}, Gio::DBus::BUS_NAME_OWNER_FLAGS_REPLACE))
+{}
 
 Daemon::~Daemon()
 {
@@ -161,7 +161,7 @@ Daemon::~Daemon()
     Gio::DBus::unown_name(owner_id);
 }
 
-const std::map<Notification::id_type, const Notification> &Daemon::getNotifications() const
+const std::map<Notification::id_type, const Notification>& Daemon::getNotifications() const
 {
     return notifications;
 }
@@ -174,12 +174,13 @@ void Daemon::closeNotification(Notification::id_type id, CloseReason reason)
     }
 
     signal_notification_closed.emit(id);
-    const auto &notification = notifications.at(id);
+    const auto & notification = notifications.at(id);
     const auto body = Glib::Variant<std::tuple<guint32, guint32>>::create({id, reason});
-    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "NotificationClosed", notification.additional_info.sender, body);
+    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "NotificationClosed",
+        notification.additional_info.sender, body);
 }
 
-void Daemon::invokeAction(Notification::id_type id, const Glib::ustring &action_key)
+void Daemon::invokeAction(Notification::id_type id, const Glib::ustring & action_key)
 {
     if (notifications.count(id) == 0)
     {
@@ -187,6 +188,7 @@ void Daemon::invokeAction(Notification::id_type id, const Glib::ustring &action_
     }
 
     const auto body = Glib::Variant<std::tuple<guint32, Glib::ustring>>::create({id, action_key});
-    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "ActionInvoked", notifications.at(id).additional_info.sender,
-                                   body);
+    daemon_connection->emit_signal(FDN_PATH, FDN_NAME, "ActionInvoked", notifications.at(
+        id).additional_info.sender,
+        body);
 }

--- a/src/panel/widgets/notifications/daemon.hpp
+++ b/src/panel/widgets/notifications/daemon.hpp
@@ -8,20 +8,20 @@
 #include <set>
 
 #define dbus_method(name)                                                                                              \
-    void name##dbus_method(const Glib::ustring &sender, const Glib::VariantContainerBase &parameters,                  \
-                           const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation)
+    void name ## dbus_method(const Glib::ustring & sender, const Glib::VariantContainerBase & parameters,                  \
+    const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation)
 class Daemon
 {
-    public:
+  public:
     enum CloseReason : guint32
     {
-        Expired = 1,
-        Dismissed = 2,
+        Expired      = 1,
+        Dismissed    = 2,
         MethodCalled = 3,
-        Undefined = 4,
+        Undefined    = 4,
     };
 
-    using notification_signal = sigc::signal<void(Notification::id_type)>;
+    using notification_signal = sigc::signal<void (Notification::id_type)>;
 
     notification_signal signalNotificationNew()
     {
@@ -55,11 +55,11 @@ class Daemon
 
     ~Daemon();
 
-    const std::map<Notification::id_type, const Notification> &getNotifications() const;
+    const std::map<Notification::id_type, const Notification> & getNotifications() const;
     void closeNotification(Notification::id_type id, CloseReason reason);
-    void invokeAction(Notification::id_type id, const Glib::ustring &action_key);
+    void invokeAction(Notification::id_type id, const Glib::ustring & action_key);
 
-    private:
+  private:
     inline static std::weak_ptr<Daemon> instance;
 
     std::map<Notification::id_type, const Notification> notifications;
@@ -76,17 +76,18 @@ class Daemon
 
     Daemon();
 
-    void on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &sender,
-                                  const Glib::ustring &object_path, const Glib::ustring &interface_name,
-                                  const Glib::ustring &method_name, const Glib::VariantContainerBase &parameters,
-                                  const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation);
+    void on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> & connection,
+        const Glib::ustring & sender,
+        const Glib::ustring & object_path, const Glib::ustring & interface_name,
+        const Glib::ustring & method_name, const Glib::VariantContainerBase & parameters,
+        const Glib::RefPtr<Gio::DBus::MethodInvocation> & invocation);
 
     dbus_method(GetCapabilities);
     dbus_method(Notify);
     dbus_method(CloseNotification);
     dbus_method(GetServerInformation);
 
-    void on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &name);
+    void on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection, const Glib::ustring & name);
 };
 
 #endif

--- a/src/panel/widgets/notifications/daemon.hpp
+++ b/src/panel/widgets/notifications/daemon.hpp
@@ -2,33 +2,91 @@
 #define NOTIFICATION_DAEMON_HPP
 
 #include "notification-info.hpp"
-#include <glibmm/object.h>
+
+#include <giomm/dbusconnection.h>
 
 #include <set>
 
-namespace Daemon
+#define dbus_method(name)                                                                                              \
+    void name##dbus_method(const Glib::ustring &sender, const Glib::VariantContainerBase &parameters,                  \
+                           const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation)
+class Daemon
 {
-enum CloseReason : guint32
-{
-    Expired      = 1,
-    Dismissed    = 2,
-    MethodCalled = 3,
-    Undefined    = 4,
+    public:
+    enum CloseReason : guint32
+    {
+        Expired = 1,
+        Dismissed = 2,
+        MethodCalled = 3,
+        Undefined = 4,
+    };
+
+    using notification_signal = sigc::signal<void(Notification::id_type)>;
+
+    notification_signal signalNotificationNew()
+    {
+        return signal_notification_new;
+    }
+
+    notification_signal signalNotificationReplaced()
+    {
+        return signal_notification_replaced;
+    }
+
+    notification_signal signalNotificationClosed()
+    {
+        return signal_notification_closed;
+    }
+
+    /*!
+     * Initializes and launches the daemon.
+     *
+     * Returns a shared pointer to the instance.
+     * Once there are no alive shared pointers to the instance,
+     * the daemon is automatically destroyed.
+     */
+    static std::shared_ptr<Daemon> Launch();
+
+    /*!
+     * Returns a pointer to the Daemon's instance if it exists
+     * or an empty `shared_ptr` otherwise.
+     */
+    static std::shared_ptr<Daemon> Instance();
+
+    ~Daemon();
+
+    const std::map<Notification::id_type, const Notification> &getNotifications() const;
+    void closeNotification(Notification::id_type id, CloseReason reason);
+    void invokeAction(Notification::id_type id, const Glib::ustring &action_key);
+
+    private:
+    inline static std::weak_ptr<Daemon> instance;
+
+    std::map<Notification::id_type, const Notification> notifications;
+
+    guint owner_id = 0;
+    guint object_id;
+    Glib::RefPtr<Gio::DBus::Connection> daemon_connection;
+
+    notification_signal signal_notification_new;
+    notification_signal signal_notification_replaced;
+    notification_signal signal_notification_closed;
+
+    const Gio::DBus::InterfaceVTable interface_vtable{sigc::mem_fun(this, &Daemon::on_interface_method_call)};
+
+    Daemon();
+
+    void on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &sender,
+                                  const Glib::ustring &object_path, const Glib::ustring &interface_name,
+                                  const Glib::ustring &method_name, const Glib::VariantContainerBase &parameters,
+                                  const Glib::RefPtr<Gio::DBus::MethodInvocation> &invocation);
+
+    dbus_method(GetCapabilities);
+    dbus_method(Notify);
+    dbus_method(CloseNotification);
+    dbus_method(GetServerInformation);
+
+    void on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> &connection, const Glib::ustring &name);
 };
-
-using notification_signal = sigc::signal<void (Notification::id_type)>;
-notification_signal signalNotificationNew();
-notification_signal signalNotificationReplaced();
-notification_signal signalNotificationClosed();
-
-sigc::signal<void> signalDaemonStopped();
-
-void start();
-void stop();
-
-const std::map<Notification::id_type, const Notification> & getNotifications();
-void closeNotification(Notification::id_type id, CloseReason reason);
-void invokeAction(Notification::id_type id, const Glib::ustring & action_key);
-} // namespace Daemon
 
 #endif

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -33,29 +33,32 @@ void WayfireNotificationCenter::init(Gtk::HBox *container)
         }
     });
 
-    for (const auto &[id, _] : daemon->getNotifications())
+    for (const auto & [id, _] : daemon->getNotifications())
     {
         newNotification(id, false);
     }
 
     notification_new_conn =
-        daemon->signalNotificationNew().connect([=](Notification::id_type id) { newNotification(id); });
+        daemon->signalNotificationNew().connect([=] (Notification::id_type id) { newNotification(id); });
     notification_replace_conn =
-        daemon->signalNotificationReplaced().connect([=](Notification::id_type id) { replaceNotification(id); });
+        daemon->signalNotificationReplaced().connect([=] (Notification::id_type id)
+    {
+        replaceNotification(id);
+    });
     notification_close_conn =
-        daemon->signalNotificationClosed().connect([=](Notification::id_type id) { closeNotification(id); });
+        daemon->signalNotificationClosed().connect([=] (Notification::id_type id) { closeNotification(id); });
 }
 
 void WayfireNotificationCenter::newNotification(Notification::id_type id, bool show_popup)
 {
-    const auto &notification = daemon->getNotifications().at(id);
+    const auto & notification = daemon->getNotifications().at(id);
     g_assert(notification_widgets.count(id) == 0);
     notification_widgets.insert({id, std::make_unique<WfSingleNotification>(notification)});
     auto & widget = notification_widgets.at(id);
     vbox.pack_end(*widget);
     vbox.show_all();
     widget->set_reveal_child();
-    if (show_popup && !dnd_enabled || (show_critical_in_dnd && notification.hints.urgency == 2))
+    if (show_popup && !dnd_enabled || (show_critical_in_dnd && (notification.hints.urgency == 2)))
     {
         auto *popover = button->get_popover();
         if ((timeout > 0) && (!popover_timeout.empty() || !popover->is_visible()))

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -4,22 +4,16 @@
 
 #include <gtk-utils.hpp>
 
-#include "daemon.hpp"
 #include "single-notification.hpp"
 
 void WayfireNotificationCenter::init(Gtk::HBox *container)
 {
-    Daemon::start();
-    Daemon::signalNotificationNew().connect([=] (Notification::id_type id) { newNotification(id); });
-    Daemon::signalNotificationReplaced().connect([=] (Notification::id_type id) { replaceNotification(id); });
-    Daemon::signalNotificationClosed().connect([=] (Notification::id_type id) { closeNotification(id); });
-    Daemon::signalDaemonStopped().connect([=] { onDaemonStop(); });
-
     button = std::make_unique<WayfireMenuButton>("panel");
 
     updateIcon();
     button->add(icon);
     container->add(*button);
+    button->show_all();
 
     auto *popover = button->get_popover();
     popover->set_size_request(WIDTH, HEIGHT);
@@ -28,10 +22,6 @@ void WayfireNotificationCenter::init(Gtk::HBox *container)
     scrolled_window.add(vbox);
     scrolled_window.show_all();
     popover->add(scrolled_window);
-
-    status_label.show();
-    status_label.set_line_wrap();
-    status_label.set_line_wrap_mode(Pango::WRAP_WORD);
 
     button->set_tooltip_text("Middle click to toggle DND mode.");
     button->signal_button_press_event().connect_notify([=] (GdkEventButton *ev)
@@ -42,18 +32,30 @@ void WayfireNotificationCenter::init(Gtk::HBox *container)
             updateIcon();
         }
     });
+
+    for (const auto &[id, _] : daemon->getNotifications())
+    {
+        newNotification(id, false);
+    }
+
+    notification_new_conn =
+        daemon->signalNotificationNew().connect([=](Notification::id_type id) { newNotification(id); });
+    notification_replace_conn =
+        daemon->signalNotificationReplaced().connect([=](Notification::id_type id) { replaceNotification(id); });
+    notification_close_conn =
+        daemon->signalNotificationClosed().connect([=](Notification::id_type id) { closeNotification(id); });
 }
 
-void WayfireNotificationCenter::newNotification(Notification::id_type id)
+void WayfireNotificationCenter::newNotification(Notification::id_type id, bool show_popup)
 {
-    const auto & notification = Daemon::getNotifications().at(id);
+    const auto &notification = daemon->getNotifications().at(id);
     g_assert(notification_widgets.count(id) == 0);
     notification_widgets.insert({id, std::make_unique<WfSingleNotification>(notification)});
     auto & widget = notification_widgets.at(id);
     vbox.pack_end(*widget);
     vbox.show_all();
     widget->set_reveal_child();
-    if (!dnd_enabled || (show_critical_in_dnd && (notification.hints.urgency == 2)))
+    if (show_popup && !dnd_enabled || (show_critical_in_dnd && notification.hints.urgency == 2))
     {
         auto *popover = button->get_popover();
         if ((timeout > 0) && (!popover_timeout.empty() || !popover->is_visible()))
@@ -102,12 +104,6 @@ void WayfireNotificationCenter::closeNotification(Notification::id_type id)
     auto & widget = notification_widgets.at(id);
     widget->property_child_revealed().signal_changed().connect([=] { notification_widgets.erase(id); });
     widget->set_reveal_child(false);
-}
-
-void WayfireNotificationCenter::onDaemonStop()
-{
-    button->get_popover()->remove();
-    button->get_popover()->add(status_label);
 }
 
 void WayfireNotificationCenter::updateIcon()

--- a/src/panel/widgets/notifications/notification-center.hpp
+++ b/src/panel/widgets/notifications/notification-center.hpp
@@ -2,7 +2,9 @@
 #define NOTIFICATION_CENTER_HPP
 
 #include "../../widget.hpp"
+#include "daemon.hpp"
 #include "single-notification.hpp"
+
 #include <gtkmm/scrolledwindow.h>
 #include <wf-popover.hpp>
 
@@ -10,20 +12,22 @@ class WayfireNotificationCenter : public WayfireWidget
 {
   private:
     static const int WIDTH = 300, HEIGHT = 400;
+
+    const std::shared_ptr<Daemon> daemon = Daemon::Launch();
+    sigc::connection notification_new_conn;
+    sigc::connection notification_replace_conn;
+    sigc::connection notification_close_conn;
+
     Gtk::Image icon;
     std::unique_ptr<WayfireMenuButton> button;
     Gtk::ScrolledWindow scrolled_window;
     Gtk::VBox vbox;
 
-    Gtk::Label status_label = Gtk::Label(
-        "Cannot start notifications daemon. Probably another one is already running.");
-
     std::map<Notification::id_type, std::unique_ptr<WfSingleNotification>> notification_widgets = {};
 
-    void newNotification(Notification::id_type id);
+    void newNotification(Notification::id_type id, bool show_popup = true);
     void replaceNotification(Notification::id_type id);
     void closeNotification(Notification::id_type id);
-    void onDaemonStop();
     void updateIcon();
 
     sigc::connection popover_timeout;
@@ -34,7 +38,12 @@ class WayfireNotificationCenter : public WayfireWidget
 
   public:
     void init(Gtk::HBox *container) override;
-    ~WayfireNotificationCenter() override = default;
+    ~WayfireNotificationCenter() override
+    {
+        notification_new_conn.disconnect();
+        notification_replace_conn.disconnect();
+        notification_close_conn.disconnect();
+    }
 };
 
 #endif

--- a/src/panel/widgets/notifications/single-notification.cpp
+++ b/src/panel/widgets/notifications/single-notification.cpp
@@ -135,14 +135,16 @@ WfSingleNotification::WfSingleNotification(const Notification & notification)
             } else
             {
                 default_action_ev_box.signal_button_press_event().connect(
-                    [id = notification.id, action_key](GdkEventButton *ev) {
-                        if (ev->button == GDK_BUTTON_PRIMARY)
-                        {
-                            Daemon::Instance()->invokeAction(id, action_key);
-                            return false;
-                        }
-                        return true;
-                    });
+                    [id = notification.id, action_key] (GdkEventButton *ev)
+                {
+                    if (ev->button == GDK_BUTTON_PRIMARY)
+                    {
+                        Daemon::Instance()->invokeAction(id, action_key);
+                        return false;
+                    }
+
+                    return true;
+                });
             }
         }
 

--- a/src/panel/widgets/notifications/single-notification.cpp
+++ b/src/panel/widgets/notifications/single-notification.cpp
@@ -84,7 +84,7 @@ WfSingleNotification::WfSingleNotification(const Notification & notification)
     close_button.add(close_image);
     close_button.get_style_context()->add_class("flat");
     close_button.signal_clicked().connect(
-        [=] { Daemon::closeNotification(notification.id, Daemon::CloseReason::Dismissed); });
+        [=] { Daemon::Instance()->closeNotification(notification.id, Daemon::CloseReason::Dismissed); });
     top_bar.pack_start(close_button, false, true);
     top_bar.set_spacing(5);
 
@@ -130,21 +130,19 @@ WfSingleNotification::WfSingleNotification(const Notification & notification)
             {
                 auto action_button = Glib::RefPtr<Gtk::Button>(new Gtk::Button(notification.actions[i + 1]));
                 action_button->signal_clicked().connect(
-                    [id = notification.id, action_key] { Daemon::invokeAction(id, action_key); });
+                    [id = notification.id, action_key] { Daemon::Instance()->invokeAction(id, action_key); });
                 actions.add(*action_button.get());
             } else
             {
                 default_action_ev_box.signal_button_press_event().connect(
-                    [id = notification.id, action_key] (GdkEventButton *ev)
-                {
-                    if (ev->button == GDK_BUTTON_PRIMARY)
-                    {
-                        Daemon::invokeAction(id, action_key);
-                        return false;
-                    }
-
-                    return true;
-                });
+                    [id = notification.id, action_key](GdkEventButton *ev) {
+                        if (ev->button == GDK_BUTTON_PRIMARY)
+                        {
+                            Daemon::Instance()->invokeAction(id, action_key);
+                            return false;
+                        }
+                        return true;
+                    });
             }
         }
 


### PR DESCRIPTION
Fixes an awful mistake: `Daemon` was a namespace instead of singleton. 
Fixes that notifications center disappears after widgets reloading.