### PR TITLE
sni: use `service` value according to the specs

### DIFF
--- a/src/panel/widgets/tray/watcher.cpp
+++ b/src/panel/widgets/tray/watcher.cpp
@@ -139,7 +139,7 @@ void Watcher::on_interface_method_call(const Glib::RefPtr<Gio::DBus::Connection>
     const auto service = service_variant.get();
     if (method_name == "RegisterStatusNotifierItem")
     {
-        register_status_notifier_item(connection, sender,
+        register_status_notifier_item(connection, service[0] == '/' ? sender : service,
             service[0] == '/' ? service : "/StatusNotifierItem");
     } else if (method_name == "RegisterStatusNotifierHost")
     {


### PR DESCRIPTION
Now it works with `copyq`