### PR TITLE
clock: use pack_start to be placed correctly between other widgets

### DIFF
--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -16,7 +16,7 @@ void WayfireClock::init(Gtk::HBox *container)
     button->get_popover()->signal_show().connect_notify(
         sigc::mem_fun(this, &WayfireClock::on_calendar_shown));
 
-    container->pack_end(*button, false, false);
+    container->pack_start(*button, false, false);
 
     timeout = Glib::signal_timeout().connect_seconds(
         sigc::mem_fun(this, &WayfireClock::update_label), 1);


### PR DESCRIPTION
Fixes #135 

Currently `clock` widget is always placed at right regardless of its position in config file (e.g. `battery clock` or `clock battery` produces the same result). IMHO, this behavior seems weird. 