### PR TITLE
Fix excusive zone when `zwf_shell_manager_v2` is unavailable

### DIFF
--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -284,7 +284,7 @@ void WayfireAutohidingWindow::update_auto_exclusive_zone()
 
 void  WayfireAutohidingWindow::set_auto_exclusive_zone(bool has_zone)
 {
-    if (has_zone && autohide_enabled)
+    if (has_zone && (output->output && autohide_opt))
     {
         std::cerr << "WARNING: Trying to enable auto_exclusive_zone with " <<
             "autohide enabled might look jarring; preventing it." << std::endl;
@@ -446,9 +446,8 @@ void WayfireAutohidingWindow::setup_autohide()
             "autohide (is compositor's wayfire-shell plugin enabled?)" <<
             std::endl;
     }
-    autohide_enabled = output->output && autohide_opt;
 
-    this->set_auto_exclusive_zone(!autohide_enabled);
+    this->set_auto_exclusive_zone(!(output->output && autohide_opt));
     this->update_autohide();
 
     this->signal_size_allocate().connect_notify(
@@ -458,7 +457,7 @@ void WayfireAutohidingWindow::setup_autohide()
         this->update_auto_exclusive_zone();
 
         // We have to check here as well, otherwise it enables hotspot when it shouldn't
-        if (!output->output|| !autohide_enabled)
+        if (!output->output|| !(output->output && autohide_opt))
         {
             return;
         }
@@ -469,12 +468,12 @@ void WayfireAutohidingWindow::setup_autohide()
 
 void WayfireAutohidingWindow::update_autohide()
 {
-    if (autohide_enabled == last_autohide_value)
+    if ((output->output && autohide_opt) == last_autohide_value)
     {
         return;
     }
 
-    if (autohide_enabled)
+    if (output->output && autohide_opt)
     {
         increase_autohide();
     } else
@@ -482,6 +481,6 @@ void WayfireAutohidingWindow::update_autohide()
         decrease_autohide();
     }
 
-    last_autohide_value = autohide_enabled;
+    last_autohide_value = output->output && autohide_opt;
     setup_auto_exclusive_zone();
 }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -42,17 +42,13 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
         }
     });
 
-    if (output->output)
-    {
-        zwf_support = true;
-    }
     this->setup_autohide();
 
     this->edge_offset.set_callback([=] () { this->setup_hotspot(); });
 
     this->autohide_opt.set_callback([=] { setup_autohide(); });
 
-    if (!this->zwf_support)
+    if (!output->output)
     {
         std::cerr << "WARNING: Compositor does not support zwf_shell_manager_v2 " << \
             "disabling hotspot and autohide features " << \
@@ -149,7 +145,7 @@ void WayfireAutohidingWindow::update_position()
     GtkLayerShellEdge anchor = get_anchor_edge(position);
     gtk_layer_set_anchor(this->gobj(), anchor, true);
 
-    if (!this->zwf_support)
+    if (!output->output)
     {
         return;
     }
@@ -443,14 +439,14 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
 
 void WayfireAutohidingWindow::setup_autohide()
 {
-    if (!zwf_support && autohide_opt)
+    if (!output->output && autohide_opt)
     {
         std::cerr << "WARNING: Attempting to enable autohide, but the " <<
             "compositor does not support zwf_shell_manager_v2; ignoring" <<
             "autohide (is compositor's wayfire-shell plugin enabled?)" <<
             std::endl;
     }
-    autohide_enabled = zwf_support && autohide_opt;
+    autohide_enabled = output->output && autohide_opt;
 
     this->set_auto_exclusive_zone(!autohide_enabled);
     this->update_autohide();
@@ -462,7 +458,7 @@ void WayfireAutohidingWindow::setup_autohide()
         this->update_auto_exclusive_zone();
 
         // We have to check here as well, otherwise it enables hotspot when it shouldn't
-        if (!this->zwf_support || !autohide_enabled)
+        if (!output->output|| !autohide_enabled)
         {
             return;
         }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -42,26 +42,23 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
         }
     });
 
-    set_auto_exclusive_zone(!autohide_opt);
+    if (output->output)
+    {
+        zwf_support = true;
+    }
+    this->setup_autohide();
 
-    if (!output->output)
+    this->edge_offset.set_callback([=] () { this->setup_hotspot(); });
+
+    this->autohide_opt.set_callback([=] { setup_autohide(); });
+
+    if (!this->zwf_support)
     {
         std::cerr << "WARNING: Compositor does not support zwf_shell_manager_v2 " << \
             "disabling hotspot and autohide features " << \
             "(is wayfire-shell plugin enabled?)" << std::endl;
-        return;
+            return;
     }
-
-    this->signal_size_allocate().connect_notify(
-        [=] (Gtk::Allocation&)
-    {
-        this->set_auto_exclusive_zone(this->has_auto_exclusive_zone);
-        this->setup_hotspot();
-    });
-
-    this->edge_offset.set_callback([=] () { this->setup_hotspot(); });
-
-    this->autohide_opt.set_callback([=] { update_autohide(); });
 
     static const zwf_output_v2_listener listener = {
         .enter_fullscreen = [] (void *data, zwf_output_v2*)
@@ -152,7 +149,7 @@ void WayfireAutohidingWindow::update_position()
     GtkLayerShellEdge anchor = get_anchor_edge(position);
     gtk_layer_set_anchor(this->gobj(), anchor, true);
 
-    if (!this->output->output)
+    if (!this->zwf_support)
     {
         return;
     }
@@ -267,16 +264,38 @@ void WayfireAutohidingWindow::setup_hotspot()
         panel_callbacks.get());
 }
 
-void WayfireAutohidingWindow::set_auto_exclusive_zone(bool has_zone)
+void WayfireAutohidingWindow::setup_auto_exclusive_zone()
 {
-    this->has_auto_exclusive_zone = has_zone;
-    int target_zone = has_zone ? get_allocated_height() : 0;
-
-    if (this->last_zone != target_zone)
+    if (!auto_exclusive_zone && auto_exclusive_zone == 0)
     {
-        gtk_layer_set_exclusive_zone(this->gobj(), target_zone);
-        last_zone = target_zone;
+        return;
     }
+
+    this->update_auto_exclusive_zone();
+}
+
+void WayfireAutohidingWindow::update_auto_exclusive_zone()
+{
+    int allocated_height = get_allocated_height();
+    int new_zone_size = this->auto_exclusive_zone ? allocated_height : 0;
+
+    if (new_zone_size != this->auto_exclusive_zone_size)
+    {
+        gtk_layer_set_exclusive_zone(this->gobj(), new_zone_size);
+        this->auto_exclusive_zone_size = new_zone_size;
+    }
+}
+
+void  WayfireAutohidingWindow::set_auto_exclusive_zone(bool has_zone)
+{
+    if (has_zone && autohide_enabled)
+    {
+        std::cerr << "WARNING: Trying to enable auto_exclusive_zone with " <<
+            "autohide enabled might look jarring; preventing it." << std::endl;
+        return;
+    }
+
+    auto_exclusive_zone = has_zone;
 }
 
 void WayfireAutohidingWindow::increase_autohide()
@@ -422,14 +441,44 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     }
 }
 
+void WayfireAutohidingWindow::setup_autohide()
+{
+    if (!zwf_support && autohide_opt)
+    {
+        std::cerr << "WARNING: Attempting to enable autohide, but the " <<
+            "compositor does not support zwf_shell_manager_v2; ignoring" <<
+            "autohide (is compositor's wayfire-shell plugin enabled?)" <<
+            std::endl;
+    }
+    autohide_enabled = zwf_support && autohide_opt;
+
+    this->set_auto_exclusive_zone(!autohide_enabled);
+    this->update_autohide();
+
+    this->signal_size_allocate().connect_notify(
+        [=] (Gtk::Allocation&)
+    {
+        //std::cerr << "set_auto_exclusive_zone: " << this->auto_exclusive_zone << std::endl;
+        this->update_auto_exclusive_zone();
+
+        // We have to check here as well, otherwise it enables hotspot when it shouldn't
+        if (!this->zwf_support || !autohide_enabled)
+        {
+            return;
+        }
+
+        this->setup_hotspot();
+    });
+}
+
 void WayfireAutohidingWindow::update_autohide()
 {
-    if (autohide_opt == last_autohide_value)
+    if (autohide_enabled == last_autohide_value)
     {
         return;
     }
 
-    if (autohide_opt)
+    if (autohide_enabled)
     {
         increase_autohide();
     } else
@@ -437,6 +486,6 @@ void WayfireAutohidingWindow::update_autohide()
         decrease_autohide();
     }
 
-    last_autohide_value = autohide_opt;
-    set_auto_exclusive_zone(!autohide_opt);
+    last_autohide_value = autohide_enabled;
+    setup_auto_exclusive_zone();
 }

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -89,11 +89,15 @@ class WayfireAutohidingWindow : public Gtk::Window
     int last_edge_offset = -1;
 
     WfOption<bool> autohide_opt;
+    bool autohide_enabled = autohide_opt;
     bool last_autohide_value = autohide_opt;
+    void setup_autohide();
     void update_autohide();
 
-    bool has_auto_exclusive_zone = false;
-    int last_zone = 0;
+    bool auto_exclusive_zone = !autohide_enabled;
+    int auto_exclusive_zone_size = 0;
+    void setup_auto_exclusive_zone();
+    void update_auto_exclusive_zone();
 
     sigc::connection pending_show, pending_hide;
     bool m_do_show();
@@ -107,6 +111,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     bool input_inside_panel     = false;
     zwf_hotspot_v2 *edge_hotspot  = NULL;
     zwf_hotspot_v2 *panel_hotspot = NULL;
+    bool zwf_support = false;
     std::unique_ptr<WayfireAutohidingWindowHotspotCallbacks> edge_callbacks;
     std::unique_ptr<WayfireAutohidingWindowHotspotCallbacks> panel_callbacks;
     void setup_hotspot();

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -111,7 +111,6 @@ class WayfireAutohidingWindow : public Gtk::Window
     bool input_inside_panel     = false;
     zwf_hotspot_v2 *edge_hotspot  = NULL;
     zwf_hotspot_v2 *panel_hotspot = NULL;
-    bool zwf_support = false;
     std::unique_ptr<WayfireAutohidingWindowHotspotCallbacks> edge_callbacks;
     std::unique_ptr<WayfireAutohidingWindowHotspotCallbacks> panel_callbacks;
     void setup_hotspot();

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -89,12 +89,11 @@ class WayfireAutohidingWindow : public Gtk::Window
     int last_edge_offset = -1;
 
     WfOption<bool> autohide_opt;
-    bool autohide_enabled = autohide_opt;
     bool last_autohide_value = autohide_opt;
     void setup_autohide();
     void update_autohide();
 
-    bool auto_exclusive_zone = !autohide_enabled;
+    bool auto_exclusive_zone = !autohide_opt;
     int auto_exclusive_zone_size = 0;
     void setup_auto_exclusive_zone();
     void update_auto_exclusive_zone();


### PR DESCRIPTION
Commit 6652635 fixed autohide issues when `zwf_shell_manager_v2` isn't available, but changed, as a side effect, the behaviour of the window's `auto_exclusive_zone`, causing an unnecessary dependency on the `zwf_shell_manager_v2` for the exclusive zone as well, affecting wf-panel when the compositor's wayfire-shell plugin is disabled (see issue #198 for details).

Fix it by refactoring the `WayfireAutohidingWindow` class, dividing some methods charged with too much roles (i.e the
`WayfireAutohidingWindow::set_autoexclusive_zone()`), transfering constructor code into new methods, introducing some new logic controls both in the class body and in the callbacks.

### Testing
To ensure everything is working fine, I did several tests on both `wf-panel` and `wf-deck` to check the behavior under different conditions. Here's what I tested:

#### `wf-panel`
I tested it both with the wayfire-shell plugin enabled and disabled, and changing the autohide config on the fly, both by starting it enabled and disabled. I looked for some key behaviors, and it worked as expected (by me, at least) on different scenarios. Here I'm pasting my notes on it while I tested:

S->wayfire-shell plugin loaded at beginning
I->initial autohide value
C{1,2}->Changes of autohide value 1 and 2

Test	Status	S	I	C1	C2
1	Success	0	0	1	0
2	Success	0	1	0	1
3	Success	1	0	1	0
4	Success	1	1	0	1

Results:

Test Scenario Id #1
[y] Show zwf_shell_manager_v2 disabled warning at startup
[y] Reposition windows out of panel's area at startup
[n] Actually enable autohide and disable exclusive zone when autohide is set to true
[y] Show swf_shell_manager_v2 disabled warning when attempts to enable autohide
[-] Reposition windows on panel's area when enable autohide
[-] Reposition windows out of pane's area when disable autohide

Test Scenario Id #2
[y] Show zwf_shell_manager_v2 disabled warning at startup
[y] Reposition windows out of panel's area at startup
[n] Actually enable autohide and disable exclusive zone when autohide is set to true
[y] Show swf_shell_manager_v2 disabled warning when attempts to enable autohide
[-] Reposition windows on panel's area when enable autohide
[-] Reposition windows out of pane's area when disable autohide

Test Scenario Id #3
[n] Show zwf_shell_manager_v2 disabled warning at startup
[y] Reposition windows out of panel's area at startup
[y] Actually enable autohide and disable exclusive zone when autohide is set to true
[n] Show swf_shell_manager_v2 disabled warning when attempts to enable autohide
[y] Reposition windows on panel's area when enable autohide
[y] Reposition windows out of pane's area when disable autohide (*)

Test Scenario Id #4
[n] Show zwf_shell_manager_v2 disabled warning at startup
[n] Reposition windows out of panel's area at startup
[y] Actually enable autohide and disable exclusive zone when autohide is set to true
[n] Show swf_shell_manager_v2 disabled warning when attempts to enable autohide
[y] Reposition windows on panel's area when enable autohide
[y] Reposition windows out of pane's area when disable autohide (*)

(*) Sometimes it needs to move the mouse over the edge to make the panel visible again

#### `wf-dock`
Since here there aren't as much factors as in `wf-panel`, I just tested it by opening it with and without the `zwf_shell_manager_v2` connected. In both cases it behaved as expected, with autohiding enabled when the shell manager is available, and disabled when not.