### PR TITLE
wf-background: allow seamless background updates

### DIFF
--- a/metadata/background.xml.in
+++ b/metadata/background.xml.in
@@ -13,6 +13,10 @@
 		<_short>Cycle Timeout</_short>
 		<default>150</default>
 	</option>
+	<option name="fade_duration" type="int">
+		<_short>Fade Duration</_short>
+		<default>1000</default>
+	</option>
 	<option name="randomize" type="bool">
 		<_short>Randomize</_short>
 		<default>false</default>

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -35,6 +35,12 @@ void BackgroundDrawingArea::show_image(Glib::RefPtr<Gdk::Pixbuf> image,
 
     to_image.x = offset_x / this->get_scale_factor();
     to_image.y = offset_y / this->get_scale_factor();
+
+    fade = {
+        fade_duration,
+        wf::animation::smoothing::linear
+    };
+
     fade.animate(from_image.source ? 0.0 : 1.0, 1.0);
 
     Glib::signal_idle().connect_once([=] ()

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -100,7 +100,7 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     return pbuf;
 }
 
-bool WayfireBackground::change_background(int timer)
+bool WayfireBackground::change_background()
 {
     Glib::RefPtr<Gdk::Pixbuf> pbuf;
     std::string path;
@@ -248,8 +248,8 @@ void WayfireBackground::reset_cycle_timeout()
     change_bg_conn.disconnect();
     if (images.size())
     {
-        change_bg_conn = Glib::signal_timeout().connect(sigc::bind(sigc::mem_fun(
-            this, &WayfireBackground::change_background), 0), cycle_timeout);
+        change_bg_conn = Glib::signal_timeout().connect(sigc::mem_fun(
+            this, &WayfireBackground::change_background), cycle_timeout);
     }
 }
 

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -15,6 +15,7 @@
 
 #include <gtk-utils.hpp>
 #include <gtk-layer-shell.h>
+#include <glib-unix.h>
 
 #include "background.hpp"
 
@@ -322,6 +323,7 @@ class WayfireBackgroundApp : public WayfireShellApp
     {
         WayfireShellApp::instance =
             std::make_unique<WayfireBackgroundApp>(argc, argv);
+        g_unix_signal_add(SIGUSR1, sigusr1_handler, (void*)instance.get());
         instance->run();
     }
 
@@ -334,6 +336,16 @@ class WayfireBackgroundApp : public WayfireShellApp
     void handle_output_removed(WayfireOutput *output) override
     {
         backgrounds.erase(output);
+    }
+
+    static gboolean sigusr1_handler(void *instance)
+    {
+        for (const auto& [_, bg] : ((WayfireBackgroundApp*)instance)->backgrounds)
+        {
+            bg->change_background();
+        }
+
+        return TRUE;
     }
 };
 

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -60,7 +60,6 @@ class WayfireBackground
 
     Glib::RefPtr<Gdk::Pixbuf> create_from_file_safe(std::string path);
     bool background_transition_frame(int timer);
-    bool change_background();
     bool load_images_from_dir(std::string path);
     bool load_next_background(Glib::RefPtr<Gdk::Pixbuf> & pbuf, std::string & path);
     void reset_background();
@@ -71,4 +70,5 @@ class WayfireBackground
 
   public:
     WayfireBackground(WayfireShellApp *app, WayfireOutput *output);
+    bool change_background();
 };

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -18,10 +18,9 @@ class BackgroundImage
 
 class BackgroundDrawingArea : public Gtk::DrawingArea
 {
-    wf::animation::simple_animation_t fade{
-        wf::create_option(1000),
-        wf::animation::smoothing::linear
-    };
+    wf::animation::simple_animation_t fade;
+    WfOption<int> fade_duration{"background/fade_duration"};
+
     /* These two pixbufs are used for fading one background
      * image to the next when changing backgrounds or when
      * automatically cycling through a directory of images.

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -61,7 +61,7 @@ class WayfireBackground
 
     Glib::RefPtr<Gdk::Pixbuf> create_from_file_safe(std::string path);
     bool background_transition_frame(int timer);
-    bool change_background(int timer);
+    bool change_background();
     bool load_images_from_dir(std::string path);
     bool load_next_background(Glib::RefPtr<Gdk::Pixbuf> & pbuf, std::string & path);
     void reset_background();


### PR DESCRIPTION
This adds two minor features to wf-background:
- The ability to set the fade duration (including to zero).
- The ability to update/cycle the background by sending SIGHUP.

Together, these can be allowed to implement seamless background
updates of slow-moving scenes. As an example, my background is an
image recalculated by xplanet every few minutes. I run xplanet
with a post_command that sends a SIGHUP to wf-background.
With a fade duration of zero, wf-background just replaces the
image imperceptibly, with no fading and no flicker.