### PR TITLE
Listen for toggle_menu event

### DIFF
--- a/proto/wayfire-shell-unstable-v2.xml
+++ b/proto/wayfire-shell-unstable-v2.xml
@@ -87,6 +87,14 @@
       <arg name="timeout" type="uint" summary="minimum time for the mouse to be in the hotspot"/>
       <arg name="id" type="new_id" interface="zwf_hotspot_v2"/>
     </request>
+
+    <event name="toggle_menu">
+      <description summary="Toggle menu event">
+        Tells the menu to open.
+
+        Emitted using an activator binding.
+      </description>
+    </event>
   </interface>
 
   <interface name="zwf_hotspot_v2" version="1">

--- a/proto/wayfire-shell-unstable-v2.xml
+++ b/proto/wayfire-shell-unstable-v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="wayfire_shell_unstable_v2">
-  <interface name="zwf_shell_manager_v2" version="1">
+  <interface name="zwf_shell_manager_v2" version="2">
     <description summary="DE integration">
       This protocol provides additional events and requests for special DE
       clients like panels, docks, etc.
@@ -21,7 +21,7 @@
     </request>
   </interface>
 
-  <interface name="zwf_output_v2" version="1">
+  <interface name="zwf_output_v2" version="2">
     <description summary="A wrapper for wl_output">
       Represents a single output.
       Each output is managed independently from the others.
@@ -88,9 +88,10 @@
       <arg name="id" type="new_id" interface="zwf_hotspot_v2"/>
     </request>
 
-    <event name="toggle_menu">
+    <!-- Version 2 additions -->
+    <event name="toggle_menu" since="2">
       <description summary="Toggle menu event">
-        Tells the menu to open.
+        Tells the menu to toggle open or close.
 
         Emitted using an activator binding.
       </description>

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -162,7 +162,7 @@ class WayfirePanel::impl
     {
         if (name == "menu")
         {
-            return Widget(new WayfireMenu());
+            return Widget(new WayfireMenu(output));
         }
 
         if (name == "launchers")

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -494,6 +494,8 @@ static void app_info_changed(GAppInfoMonitor *gappinfomonitor, gpointer user_dat
 
 void WayfireMenu::init(Gtk::HBox *container)
 {
+    output->toggle_menu_signal().connect(sigc::mem_fun(this, &WayfireMenu::toggle_menu));
+
     menu_icon.set_callback([=] () { update_icon(); });
     menu_size.set_callback([=] () { update_icon(); });
     panel_position.set_callback([=] () { update_popover_layout(); });
@@ -535,6 +537,17 @@ void WayfireMenu::init(Gtk::HBox *container)
     hbox.show();
     main_image.show();
     button->show();
+}
+
+void WayfireMenu::toggle_menu()
+{
+    if (button->get_active())
+    {
+        button->set_active(false);
+    } else
+    {
+        button->set_active(true);
+    }
 }
 
 void WayfireMenu::hide_menu()

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -79,6 +79,8 @@ class WayfireLogoutUI
 
 class WayfireMenu : public WayfireWidget
 {
+    WayfireOutput *output;
+
     Gtk::Box flowbox_container;
     Gtk::HBox hbox, hbox_bottom;
     Gtk::VBox bottom_pad;
@@ -127,8 +129,14 @@ class WayfireMenu : public WayfireWidget
 
   public:
     void init(Gtk::HBox *container) override;
+    void toggle_menu();
     void hide_menu();
     void refresh();
+    WayfireMenu(WayfireOutput *output)
+    {
+        this->output = output;
+    }
+
     ~WayfireMenu() override
     {
         g_signal_handler_disconnect(app_info_monitor, app_info_monitor_changed_handler_id);

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -53,7 +53,7 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
         std::cerr << "WARNING: Compositor does not support zwf_shell_manager_v2 " << \
             "disabling hotspot and autohide features " << \
             "(is wayfire-shell plugin enabled?)" << std::endl;
-            return;
+        return;
     }
 
     static const zwf_output_v2_listener listener = {
@@ -64,7 +64,11 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
         .leave_fullscreen = [] (void *data, zwf_output_v2*)
         {
             ((WayfireAutohidingWindow*)data)->decrease_autohide();
-        }
+        },
+        .toggle_menu = [] (void *data, zwf_output_v2*)
+        {
+            ((WayfireAutohidingWindow*)data)->output->toggle_menu_signal().emit();
+        },
     };
     zwf_output_v2_add_listener(output->output, &listener, this);
 }
@@ -262,7 +266,7 @@ void WayfireAutohidingWindow::setup_hotspot()
 
 void WayfireAutohidingWindow::setup_auto_exclusive_zone()
 {
-    if (!auto_exclusive_zone && auto_exclusive_zone == 0)
+    if (!auto_exclusive_zone && (auto_exclusive_zone == 0))
     {
         return;
     }
@@ -273,7 +277,7 @@ void WayfireAutohidingWindow::setup_auto_exclusive_zone()
 void WayfireAutohidingWindow::update_auto_exclusive_zone()
 {
     int allocated_height = get_allocated_height();
-    int new_zone_size = this->auto_exclusive_zone ? allocated_height : 0;
+    int new_zone_size    = this->auto_exclusive_zone ? allocated_height : 0;
 
     if (new_zone_size != this->auto_exclusive_zone_size)
     {
@@ -282,7 +286,7 @@ void WayfireAutohidingWindow::update_auto_exclusive_zone()
     }
 }
 
-void  WayfireAutohidingWindow::set_auto_exclusive_zone(bool has_zone)
+void WayfireAutohidingWindow::set_auto_exclusive_zone(bool has_zone)
 {
     if (has_zone && (output->output && autohide_opt))
     {
@@ -453,11 +457,11 @@ void WayfireAutohidingWindow::setup_autohide()
     this->signal_size_allocate().connect_notify(
         [=] (Gtk::Allocation&)
     {
-        //std::cerr << "set_auto_exclusive_zone: " << this->auto_exclusive_zone << std::endl;
+        // std::cerr << "set_auto_exclusive_zone: " << this->auto_exclusive_zone << std::endl;
         this->update_auto_exclusive_zone();
 
         // We have to check here as well, otherwise it enables hotspot when it shouldn't
-        if (!output->output|| !(output->output && autohide_opt))
+        if (!output->output || !(output->output && autohide_opt))
         {
             return;
         }

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -93,7 +93,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     void setup_autohide();
     void update_autohide();
 
-    bool auto_exclusive_zone = !autohide_opt;
+    bool auto_exclusive_zone     = !autohide_opt;
     int auto_exclusive_zone_size = 0;
     void setup_auto_exclusive_zone();
     void update_auto_exclusive_zone();

--- a/src/util/wf-shell-app.cpp
+++ b/src/util/wf-shell-app.cpp
@@ -66,7 +66,7 @@ static void registry_add_object(void *data, struct wl_registry *registry,
     if (strcmp(interface, zwf_shell_manager_v2_interface.name) == 0)
     {
         app->wf_shell_manager = (zwf_shell_manager_v2*)wl_registry_bind(registry, name,
-            &zwf_shell_manager_v2_interface, std::min(version, 1u));
+            &zwf_shell_manager_v2_interface, std::min(version, 2u));
     }
 }
 

--- a/src/util/wf-shell-app.cpp
+++ b/src/util/wf-shell-app.cpp
@@ -201,3 +201,8 @@ WayfireOutput::~WayfireOutput()
         zwf_output_v2_destroy(this->output);
     }
 }
+
+sigc::signal<void()> WayfireOutput::toggle_menu_signal()
+{
+    return m_toggle_menu_signal;
+}

--- a/src/util/wf-shell-app.hpp
+++ b/src/util/wf-shell-app.hpp
@@ -19,6 +19,8 @@ struct WayfireOutput
     GMonitor monitor;
     wl_output *wo;
     zwf_output_v2 *output;
+    sigc::signal<void()> toggle_menu_signal();
+    sigc::signal<void()> m_toggle_menu_signal;
 
     WayfireOutput(const GMonitor& monitor, zwf_shell_manager_v2 *zwf_manager);
     ~WayfireOutput();


### PR DESCRIPTION
Update wayfire-shell protocol and listen for the toggle_menu event. Fixes #11 because ipc plugin can be used to allow calling toggle_menu from a script.

Requires [wayfire PR 2097](https://github.com/WayfireWM/wayfire/pull/2097).