### PR TITLE
battery: make scroll change brightness

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -125,11 +125,6 @@
 		<default>32</default>
 		<min>1</min>
 	</option>
-	<option name="battery_scroll_sensitivity" type="double">
-		<_short>Battery Scroll Sensitivity</_short>
-		<default>1.8</default>
-		<min>0</min>
-	</option>
 	<option name="battery_icon_invert" type="bool">
 		<_short>Battery Icon Invert Color</_short>
 		<default>true</default>
@@ -137,6 +132,14 @@
 	<option name="battery_font" type="string">
 		<_short>Battery Font</_short>
 		<default>default</default>
+	</option>
+	<option name="battery_scrollup_command" type="string">
+		<_short>Battery Scroll Up Command</_short>
+		<default>brightnessctl -q set 10%+</default>
+	</option>
+	<option name="battery_scrolldown_command" type="string">
+		<_short>Battery Scroll Down Command</_short>
+		<default>brightnessctl -q set 10%-</default>
 	</option>
 	</group>
 	<group>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -125,6 +125,11 @@
 		<default>32</default>
 		<min>1</min>
 	</option>
+	<option name="battery_scroll_sensitivity" type="double">
+		<_short>Battery Scroll Sensitivity</_short>
+		<default>1.8</default>
+		<min>0</min>
+	</option>
 	<option name="battery_icon_invert" type="bool">
 		<_short>Battery Icon Invert Color</_short>
 		<default>true</default>

--- a/src/panel/widgets/battery.hpp
+++ b/src/panel/widgets/battery.hpp
@@ -23,13 +23,16 @@ class WayfireBatteryInfo : public WayfireWidget
 {
     WfOption<std::string> status_opt{"panel/battery_status"};
     WfOption<std::string> font_opt{"panel/battery_font"};
+    WfOption<std::string> battery_scrollup_command{"panel/battery_scrollup_command"};
+    WfOption<std::string> battery_scrolldown_command{"panel/battery_scrolldown_command"};
     WfOption<int> size_opt{"panel/battery_icon_size"};
-    WfOption<double> sensitivity_opt{"panel/battery_scroll_sensitivity"};
     WfOption<bool> invert_opt{"panel/battery_icon_invert"};
 
     Gtk::Button button;
     Gtk::Label label;
     Gtk::HBox button_box;
+
+    int scroll_counter;
 
     Gtk::Image icon;
 

--- a/src/panel/widgets/battery.hpp
+++ b/src/panel/widgets/battery.hpp
@@ -24,6 +24,7 @@ class WayfireBatteryInfo : public WayfireWidget
     WfOption<std::string> status_opt{"panel/battery_status"};
     WfOption<std::string> font_opt{"panel/battery_font"};
     WfOption<int> size_opt{"panel/battery_icon_size"};
+    WfOption<double> sensitivity_opt{"panel/battery_scroll_sensitivity"};
     WfOption<bool> invert_opt{"panel/battery_icon_invert"};
 
     Gtk::Button button;
@@ -41,6 +42,7 @@ class WayfireBatteryInfo : public WayfireWidget
     void update_icon();
     void update_details();
     void update_state();
+    void on_battery_scroll(GdkEventScroll *event);
 
     void on_properties_changed(
         const Gio::DBus::Proxy::MapChangedProperties& properties,

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -186,6 +186,10 @@ class WayfireToplevel::impl
         {
             menu.popup(event->button, event->time);
             return true; // It has been handled.
+        } else if ((event->type == GDK_BUTTON_PRESS) && (event->button == 2)) // middle click
+        {
+	    zwlr_foreign_toplevel_handle_v1_close(handle);
+            return true;
         } else
         {
             return false;

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -186,10 +186,6 @@ class WayfireToplevel::impl
         {
             menu.popup(event->button, event->time);
             return true; // It has been handled.
-        } else if ((event->type == GDK_BUTTON_PRESS) && (event->button == 2)) // middle click
-        {
-	    zwlr_foreign_toplevel_handle_v1_close(handle);
-            return true;
         } else
         {
             return false;


### PR DESCRIPTION
`battery_scroll_sensitivity` is a new option that specifies the amount (in percentage points) that each scroll event will change the brightness. I found `1.8` to be a good default as a compromise between smooth (touchpad) scrolling and discrete (mouse-wheel) scrolling.

I wrote a method `change_brightness()` which reads and writes to `/sys/class/backlight/` to change the brightness. This requires that the running user be in the `video` group. Personally I'm fine with this but I want to hear what everyone else thinks.

If I break some conventions here I apologize; I'm not very familiar with how you're supposed to do stuff in C++. Please let me know.

Also, I haven't tested this on any machine other than my laptop. So if it doesn't work for you also let me know.

Resolves https://github.com/WayfireWM/wf-shell/issues/207