### PR TITLE
window-list: Allow smaller panel heights

### DIFF
--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -298,9 +298,10 @@ class WayfireToplevel::impl
 
     void set_app_id(std::string app_id)
     {
+        WfOption<int> minimal_panel_height{"panel/minimal_height"};
         this->app_id = app_id;
         IconProvider::set_image_from_icon(image, app_id,
-            24, button.get_scale_factor());
+            std::min(int(minimal_panel_height), 24), button.get_scale_factor());
     }
 
     void send_rectangle_hint()
@@ -734,7 +735,7 @@ void set_image_from_icon(Gtk::Image& image,
         {
             /* Perhaps no desktop app info, but we might still be able to
              * get an icon directly from the icon theme */
-            if (Gtk::IconTheme::get_default()->lookup_icon(app_id, 24))
+            if (Gtk::IconTheme::get_default()->lookup_icon(app_id, size))
             {
                 icon_name = app_id;
             }

--- a/src/panel/widgets/window-list/window-list.cpp
+++ b/src/panel/widgets/window-list/window-list.cpp
@@ -195,6 +195,7 @@ void WayfireWindowList::init(Gtk::HBox *container)
     box.set_homogeneous(true);
     scrolled_window.add(box);
     scrolled_window.set_propagate_natural_width(true);
+    scrolled_window.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_NEVER);
     container->pack_start(scrolled_window, true, true);
     scrolled_window.show_all();
 }


### PR DESCRIPTION
Set the scrolled window policy to NEVER instead of AUTOMATIC to allow it to become smaller than 32 pixels in height.