### PR TITLE
window-list: use ~/.local/share when looking for apps / icons

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
   test_musl_gcc:
     name: "Test with with GCC/musl/libstdc++/BFD on Alpine Linux"
     runs-on: ubuntu-latest
-    container: alpine:edge
+    container: alpine:latest
     steps:
     - run: echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
     - run: apk --no-cache add git g++ binutils pkgconf meson ninja musl-dev gtk+3.0-dev gtkmm3-dev wayland-protocols wayfire-dev gtk-layer-shell-dev pulseaudio-dev libdbusmenu-gtk3-dev alsa-lib-dev

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -665,11 +665,7 @@ Icon get_from_desktop_app_info(std::string app_id)
 
     std::vector<std::string> prefixes = {
         "",
-        "/usr/share/applications/",
-        "/usr/share/applications/kde/",
-        "/usr/share/applications/org.kde.",
-        "/usr/local/share/applications/",
-        "/usr/local/share/applications/org.kde.",
+        "org.kde.",
     };
 
     std::vector<std::string> app_id_variations = {
@@ -690,8 +686,7 @@ Icon get_from_desktop_app_info(std::string app_id)
             {
                 if (!app_info)
                 {
-                    app_info = Gio::DesktopAppInfo
-                        ::create_from_filename(prefix + id + suffix);
+                    app_info = Gio::DesktopAppInfo::create(prefix + id + suffix);
                 }
             }
         }


### PR DESCRIPTION
The icons in the window list are loaded by parsing the desktop files for a few variations of the window's app ID in a few known locations.

Add /.local/share/applications to the list of locations it looks in, to ensure that apps installed in the user's home directory are considered as well.