### PR TITLE
Add "Fill and Crop" option for wf-background. Pt 2

### DIFF
--- a/metadata/background.xml.in
+++ b/metadata/background.xml.in
@@ -21,9 +21,21 @@
 		<_short>Randomize</_short>
 		<default>false</default>
 	</option>
-	<option name="preserve_aspect" type="bool">
-		<_short>Preserve Aspect</_short>
-		<default>false</default>
+	<option name="fill_mode" type="string">
+		<_short>Fill mode</_short>
+		<default>stretch</default>
+		<desc>
+			<value>fill_and_crop</value>
+			<_name>Fill and Crop</_name>
+		</desc>
+		<desc>
+			<value>preserve_aspect</value>
+			<_name>Preserve Aspect</_name>
+		</desc>
+		<desc>
+			<value>stretch</value>
+			<_name>Stretch</_name>
+		</desc>
 	</option>
 	</plugin>
 </wf-shell>

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -86,40 +86,21 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     int height = window.get_allocated_height() * scale;
 
     float screen_aspect_ratio = (float) width / height;
-    float image_aspect_ratio;
 
     std::string fill_and_crop_string = "fill_and_crop";
     std::string preserve_aspect_string = "preserve_aspect";
-    std::string stretch_string = "stretch";
-
-    enum FillMode { fill_and_crop, preserve_aspect, stretch};
-    FillMode current_mode;
 
     if(! fill_and_crop_string.compare(background_fill_mode))
     {
-        current_mode = fill_and_crop;
-    } else
-    {
-        if (! preserve_aspect_string.compare(background_fill_mode))
+        try {
+            pbuf =
+                Gdk::Pixbuf::create_from_file(path, width, height,
+                    true);
+        } catch (...)
         {
-            current_mode = preserve_aspect;
-        }else
-        {
-            current_mode = stretch;
+            return Glib::RefPtr<Gdk::Pixbuf>();
         }
-    }
-
-    try {
-        pbuf =
-            Gdk::Pixbuf::create_from_file(path, width, height,
-                current_mode != stretch);
-    } catch (...)
-    {
-        return Glib::RefPtr<Gdk::Pixbuf>();
-    }
-
-    if (current_mode == fill_and_crop) {
-	    image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
+        float image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
 		bool should_fill_width = (screen_aspect_ratio > image_aspect_ratio);
 	    try {
 	        pbuf =
@@ -129,24 +110,33 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
 	    } catch (...) {
 	        return Glib::RefPtr<Gdk::Pixbuf>();
 	    }
+        offset_x = (width - pbuf->get_width()) * 0.5;
+        offset_y = (height - pbuf->get_height()) * 0.5;
+    } else if (! preserve_aspect_string.compare(background_fill_mode))
+    {
+        try {
+            pbuf =
+                Gdk::Pixbuf::create_from_file(path, width, height,
+                    true);
+        } catch (...)
+        {
+            return Glib::RefPtr<Gdk::Pixbuf>();
+        }
+        bool eq_width = (width == pbuf->get_width());
+	    offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+	    offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+    } else
+    {
+        try {
+            pbuf =
+                Gdk::Pixbuf::create_from_file(path, width, height,
+                    false);
+        } catch (...)
+        {
+            return Glib::RefPtr<Gdk::Pixbuf>();
+        }
+        offset_x = offset_y = 0.0;
     }
-    if (current_mode == stretch)
-	{
-		offset_x = offset_y = 0.0;
-	}else
-	{
-		if (current_mode == preserve_aspect) 
-		{
-		    bool eq_width = (width == pbuf->get_width());
-	        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-	        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
-		} else
-		{
-			offset_x = (width - pbuf->get_width()) * 0.5;
-        	offset_y = (height - pbuf->get_height()) * 0.5;
-		}
-	}
-
     return pbuf;
 }
 

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -123,7 +123,7 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
         float screen_aspect_ratio = (float) width / height;
         float image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
 		bool should_fill_width = (screen_aspect_ratio > image_aspect_ratio);
-        if(should_fill_width){
+        if (should_fill_width){
             image_scale = (double) width / pbuf->get_width();
             offset_y = ( ( height / image_scale ) - pbuf->get_height()) * 0.5;
             offset_x = 0;
@@ -137,8 +137,8 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     {
         bool eq_width = (width == pbuf->get_width());
         image_scale=1.0;
-	    offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-	    offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
     }
     
     return pbuf;

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -34,8 +34,8 @@ void BackgroundDrawingArea::show_image(Glib::RefPtr<Gdk::Pixbuf> image,
     to_image.source = Gdk::Cairo::create_surface_from_pixbuf(image,
         this->get_scale_factor());
 
-    to_image.x = offset_x / this->get_scale_factor();
-    to_image.y = offset_y / this->get_scale_factor();
+    to_image.x     = offset_x / this->get_scale_factor();
+    to_image.y     = offset_y / this->get_scale_factor();
     to_image.scale = image_scale;
 
     fade = {
@@ -105,11 +105,12 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
         {
             return Glib::RefPtr<Gdk::Pixbuf>();
         }
-        offset_x = offset_y = 0.0;
+
+        offset_x    = offset_y = 0.0;
         image_scale = 1.0;
         return pbuf;
     }
-    
+
     try {
         pbuf =
             Gdk::Pixbuf::create_from_file(path, width, height,
@@ -118,29 +119,31 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
+
     if (!fill_and_crop_string.compare(background_fill_mode))
     {
         float screen_aspect_ratio = (float) width / height;
-        float image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
-		bool should_fill_width = (screen_aspect_ratio > image_aspect_ratio);
-        if (should_fill_width){
-            image_scale = (double) width / pbuf->get_width();
-            offset_y = ( ( height / image_scale ) - pbuf->get_height()) * 0.5;
-            offset_x = 0;
+        float image_aspect_ratio  = (float) pbuf->get_width() / pbuf->get_height();
+		bool should_fill_width    = (screen_aspect_ratio > image_aspect_ratio);
+        if (should_fill_width)
+        {
+            image_scale = (double)width / pbuf->get_width();
+            offset_y    = ((height / image_scale) - pbuf->get_height()) * 0.5;
+            offset_x    = 0;
         } else
         {
             image_scale = (double)height / pbuf->get_height();
-            offset_x = ( ( width / image_scale )- pbuf->get_width()) * 0.5;
-            offset_y = 0;
+            offset_x    = ((width / image_scale) - pbuf->get_width()) * 0.5;
+            offset_y    = 0;
         }
     } else
     {
         bool eq_width = (width == pbuf->get_width());
         image_scale=1.0;
-        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+        offset_x   = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+        offset_y   = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
     }
-    
+
     return pbuf;
 }
 

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -85,24 +85,67 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     int width  = window.get_allocated_width() * scale;
     int height = window.get_allocated_height() * scale;
 
+    float screen_aspect_ratio = (float) width / height;
+    float image_aspect_ratio;
+
+    std::string fill_and_crop_string = "fill_and_crop";
+    std::string preserve_aspect_string = "preserve_aspect";
+    std::string stretch_string = "stretch";
+
+    enum FillMode { fill_and_crop, preserve_aspect, stretch};
+    FillMode current_mode;
+
+    if(! fill_and_crop_string.compare(background_fill_mode))
+    {
+        current_mode = fill_and_crop;
+    } else
+    {
+        if (! preserve_aspect_string.compare(background_fill_mode))
+        {
+            current_mode = preserve_aspect;
+        }else
+        {
+            current_mode = stretch;
+        }
+    }
+
     try {
         pbuf =
             Gdk::Pixbuf::create_from_file(path, width, height,
-                background_preserve_aspect);
+                current_mode != stretch);
     } catch (...)
     {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
 
-    if (background_preserve_aspect)
-    {
-        bool eq_width = (width == pbuf->get_width());
-        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
-    } else
-    {
-        offset_x = offset_y = 0.0;
+    if (current_mode == fill_and_crop) {
+	    image_aspect_ratio = (float) pbuf->get_width() / pbuf->get_height();
+		bool should_fill_width = (screen_aspect_ratio > image_aspect_ratio);
+	    try {
+	        pbuf =
+	            Gdk::Pixbuf::create_from_file(path, 
+	                should_fill_width ? width : -1, 
+	                should_fill_width ? -1 : height, true);
+	    } catch (...) {
+	        return Glib::RefPtr<Gdk::Pixbuf>();
+	    }
     }
+    if (current_mode == stretch)
+	{
+		offset_x = offset_y = 0.0;
+	}else
+	{
+		if (current_mode == preserve_aspect) 
+		{
+		    bool eq_width = (width == pbuf->get_width());
+	        offset_x = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+	        offset_y = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+		} else
+		{
+			offset_x = (width - pbuf->get_width()) * 0.5;
+        	offset_y = (height - pbuf->get_height()) * 0.5;
+		}
+	}
 
     return pbuf;
 }
@@ -289,7 +332,7 @@ void WayfireBackground::setup_window()
     auto reset_cycle = [=] () { reset_cycle_timeout(); };
     background_image.set_callback(reset_background);
     background_randomize.set_callback(reset_background);
-    background_preserve_aspect.set_callback(reset_background);
+    background_fill_mode.set_callback(reset_background);
     background_cycle_timeout.set_callback(reset_cycle);
 
     window.property_scale_factor().signal_changed().connect(

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -122,9 +122,9 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
 
     if (!fill_and_crop_string.compare(background_fill_mode))
     {
-        float screen_aspect_ratio = (float) width / height;
-        float image_aspect_ratio  = (float) pbuf->get_width() / pbuf->get_height();
-		bool should_fill_width    = (screen_aspect_ratio > image_aspect_ratio);
+        float screen_aspect_ratio = (float)width / height;
+        float image_aspect_ratio  = (float)pbuf->get_width() / pbuf->get_height();
+        bool should_fill_width    = (screen_aspect_ratio > image_aspect_ratio);
         if (should_fill_width)
         {
             image_scale = (double)width / pbuf->get_width();
@@ -139,9 +139,9 @@ Glib::RefPtr<Gdk::Pixbuf> WayfireBackground::create_from_file_safe(std::string p
     } else
     {
         bool eq_width = (width == pbuf->get_width());
-        image_scale=1.0;
-        offset_x   = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
-        offset_y   = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
+        image_scale = 1.0;
+        offset_x    = eq_width ? 0 : (width - pbuf->get_width()) * 0.5;
+        offset_y    = eq_width ? (height - pbuf->get_height()) * 0.5 : 0;
     }
 
     return pbuf;

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -12,6 +12,7 @@ class WayfireBackground;
 class BackgroundImage
 {
   public:
+    double scale;
     double x, y;
     Cairo::RefPtr<Cairo::Surface> source;
 };
@@ -32,7 +33,7 @@ class BackgroundDrawingArea : public Gtk::DrawingArea
   public:
     BackgroundDrawingArea();
     void show_image(Glib::RefPtr<Gdk::Pixbuf> image,
-        double offset_x, double offset_y);
+        double offset_x, double offset_y, double image_scale);
 
   protected:
     bool on_draw(const Cairo::RefPtr<Cairo::Context>& cr) override;
@@ -49,6 +50,7 @@ class WayfireBackground
 
     int scale;
     double offset_x, offset_y;
+    double image_scale = 1.0;
     bool inhibited = false;
     uint current_background;
     sigc::connection change_bg_conn;

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -56,7 +56,7 @@ class WayfireBackground
     WfOption<std::string> background_image{"background/image"};
     WfOption<int> background_cycle_timeout{"background/cycle_timeout"};
     WfOption<bool> background_randomize{"background/randomize"};
-    WfOption<bool> background_preserve_aspect{"background/preserve_aspect"};
+    WfOption<std::string> background_fill_mode{"background/fill_mode"};
 
     Glib::RefPtr<Gdk::Pixbuf> create_from_file_safe(std::string path);
     bool background_transition_frame(int timer);

--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -51,7 +51,7 @@ class WayfireBackground
     int scale;
     double offset_x, offset_y;
     double image_scale = 1.0;
-    bool inhibited = false;
+    bool inhibited     = false;
     uint current_background;
     sigc::connection change_bg_conn;
 

--- a/wf-shell.ini.example
+++ b/wf-shell.ini.example
@@ -1,8 +1,9 @@
 [background]
 # Full path to image or directory of images
 # image = /usr/share/wayfire/wallpaper.jpg
-# Whether to scale images or preserve background ratio
-preserve_aspect = 0
+# How to fit the image to screens
+# One of: fill_and_crop, preserve_aspect, stretch
+fill_mode = stretch
 # In the case of directory, timeout between changing backgrounds, in seconds
 cycle_timeout = 150
 # In the case of directory, whether or not to randomize images


### PR DESCRIPTION
I felt strongly about https://github.com/WayfireWM/wf-shell/pull/58 so I replicated the fork against master and followed the requested changes.

After some testing with a variety of images and screens I made further edits:
- Added an `image_scale` value that gets passed into the render logic for each image
- Added cairo context save/restore and placed a scale inside it to allow the image to be scaled up in-place without loading it a second time.

These were necessary as loading tall images in ultrawide screens or visa-versa caused a crash from attempting to create a Pixbuf that was too large.

I have attempted to stick to the coding style of the project but feel free to correct me on it.