### PR TITLE
Check for and load absolute path icons in panel launchers

### DIFF
--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,8 +34,13 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon  = app_info->get_icon()->to_string();
-        auto theme = Gtk::IconTheme::get_default();
+        auto icon                 = app_info->get_icon()->to_string();
+        auto theme                = Gtk::IconTheme::get_default();
+        std::string absolute_path = "/";
+        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
+        {
+            return Gdk::Pixbuf::create_from_file(icon, size, size);
+        }
 
         if (!theme->lookup_icon(icon, size))
         {

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,13 +34,14 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon                 = app_info->get_icon()->to_string();
-        auto theme                = Gtk::IconTheme::get_default();
+        auto icon = app_info->get_icon()->to_string();
         std::string absolute_path = "/";
-        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
+        if (!icon.compare(0, absolute_path.size(), absolute_path))
         {
             return Gdk::Pixbuf::create_from_file(icon, size, size);
         }
+
+        auto theme = Gtk::IconTheme::get_default();
 
         if (!theme->lookup_icon(icon, size))
         {


### PR DESCRIPTION
Chasing around a missing icon in launcher lead me to make this patch:

- Setting a launcher icon/cmd pair would load the image from an absolute path
- Setting a `.desktop` launcher would work if the icon was a themed icon name
- Setting a `.desktop` with an icon that has an absolute path would only attempt to look it up via theme

I did a quick sanity check here https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html :
> Icon to display in file manager, menus, etc. If the name is an absolute path, the given file will be used. If the name is not...

So I've put in a check for character at index 0 being `/` and load it from file.

While not in scope for this PR, it is worth asking if the icon/cmd pair could/should be patched to also allow loading by icon-theme-name if it doesn't begin with a `/`
