### PR TITLE
Collection of Menu alterations

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -181,6 +181,12 @@
 		<hint>file</hint>
 		<default></default>
 	</option>
+	<option name="menu_min_category_width" type="int">
+		<_short>Menu Minimum Category Width</_short>
+		<default>200</default>
+		<min>50</min>
+		<max>400</max>
+	</option>
 	<option name="menu_min_content_width" type="int">
 		<_short>Menu Minimum Content Width</_short>
 		<default>500</default>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -199,6 +199,14 @@
 		<min>100</min>
 		<max>5000</max>
 	</option>
+	<option name="menu_list" type="bool">
+		<_short>Show Menu Applications as a List</_short>
+		<default>false</default>
+	</option>
+	<option name="menu_show_categories" type="bool">
+		<_short>Show Application Categories</_short>
+		<default>false</default>
+	</option>
 	<option name="menu_logout_command" type="string">
 		<_short>Menu Logout Command</_short>
 		<_long>If not specified, a default logout interface will be used.</_long>

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,8 +34,13 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon  = app_info->get_icon()->to_string();
-        auto theme = Gtk::IconTheme::get_default();
+        auto icon                 = app_info->get_icon()->to_string();
+        auto theme                = Gtk::IconTheme::get_default();
+        std::string absolute_path = "/";
+        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
+        {
+            return Gdk::Pixbuf::create_from_file(icon, size, size);
+        }
 
         if (!theme->lookup_icon(icon, size))
         {

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,13 +34,8 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon                 = app_info->get_icon()->to_string();
-        auto theme                = Gtk::IconTheme::get_default();
-        std::string absolute_path = "/";
-        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
-        {
-            return Gdk::Pixbuf::create_from_file(icon, size, size);
-        }
+        auto icon  = app_info->get_icon()->to_string();
+        auto theme = Gtk::IconTheme::get_default();
 
         if (!theme->lookup_icon(icon, size))
         {

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,14 +34,13 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon = app_info->get_icon()->to_string();
+        auto icon                 = app_info->get_icon()->to_string();
+        auto theme                = Gtk::IconTheme::get_default();
         std::string absolute_path = "/";
-        if (!icon.compare(0, absolute_path.size(), absolute_path))
+        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
         {
             return Gdk::Pixbuf::create_from_file(icon, size, size);
         }
-
-        auto theme = Gtk::IconTheme::get_default();
 
         if (!theme->lookup_icon(icon, size))
         {

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -34,13 +34,14 @@ struct DesktopLauncherInfo : public LauncherInfo
 
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(int32_t size)
     {
-        auto icon                 = app_info->get_icon()->to_string();
-        auto theme                = Gtk::IconTheme::get_default();
+        auto icon = app_info->get_icon()->to_string();
         std::string absolute_path = "/";
-        if (!icon.compare(0, absolute_path.size(), absolute_path)) 
+        if (!icon.compare(0, absolute_path.size(), absolute_path))
         {
             return Gdk::Pixbuf::create_from_file(icon, size, size);
         }
+
+        auto theme = Gtk::IconTheme::get_default();
 
         if (!theme->lookup_icon(icon, size))
         {

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -18,16 +18,16 @@
 #define MAX_LAUNCHER_NAME_LENGTH 11
 const std::string default_icon = ICONDIR "/wayfire.png";
 
-WfMenuCategoryDefinition::WfMenuCategoryDefinition(std::string _name, std::string _icon_name) :
+WfMenuCategory::WfMenuCategory(std::string _name, std::string _icon_name) :
     name(_name), icon_name(_icon_name)
 {}
 
-std::string WfMenuCategoryDefinition::get_name()
+std::string WfMenuCategory::get_name()
 {
     return name;
 }
 
-std::string WfMenuCategoryDefinition::get_icon_name()
+std::string WfMenuCategory::get_icon_name()
 {
     return icon_name;
 }
@@ -277,9 +277,9 @@ void WayfireMenu::load_menu_item(AppInfo app_info)
 void WayfireMenu::add_category_app(std::string category, Glib::RefPtr<Gio::DesktopAppInfo> app)
 {
     /* Filter for allowed categories */
-    if (category_definitions.count(category) == 1)
+    if (category_list.count(category) == 1)
     {
-        category_definitions[category]->items.push_back(app);
+        category_list[category]->items.push_back(app);
     }
 }
 
@@ -292,21 +292,21 @@ void WayfireMenu::populate_menu_categories()
     }
 
     // Iterate allowed categories in order
-    for (auto category : category_order)
+    for (auto category_name : category_order)
     {
-        if (category_definitions.count(category) == 1)
+        if (category_list.count(category_name) == 1)
         {
-            auto& category_definition = category_definitions[category];
-            if (category_definition->items.size() > 0)
+            auto& category = category_list[category_name];
+            if (category->items.size() > 0)
             {
-                auto icon_name = category_definition->get_icon_name();
-                auto name = category_definition->get_name();
-                auto category_button = new WfMenuCategoryButton(this, category, name, icon_name);
+                auto icon_name = category->get_icon_name();
+                auto name = category->get_name();
+                auto category_button = new WfMenuCategoryButton(this, category_name, name, icon_name);
                 category_box.pack_start(*category_button);
             }
         } else
         {
-            std::cerr << "Category in order without Category Definition : " << category << std::endl;
+            std::cerr << "Category in orderlist without Category object : " << category << std::endl;
         }
     }
 
@@ -321,7 +321,7 @@ void WayfireMenu::populate_menu_items(std::string category)
         gtk_widget_destroy(GTK_WIDGET(child->gobj()));
     }
 
-    for (auto app_info : category_definitions[category]->items)
+    for (auto app_info : category_list[category]->items)
     {
         auto app = new WfMenuMenuItem(this, app_info);
         flowbox.add(*app);
@@ -698,9 +698,9 @@ void WayfireMenu::on_logout_click()
 void WayfireMenu::refresh()
 {
     loaded_apps.clear();
-    for (auto& [key, category_definition] : category_definitions)
+    for (auto& [key, category] : category_list)
     {
-        category_definition->items.clear();
+        category->items.clear();
     }
 
     for (auto child : flowbox.get_children())
@@ -726,30 +726,30 @@ void WayfireMenu::init(Gtk::HBox *container)
     /* https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry
      * Using the 'Main' categories, with names and icons assigned
      * Any Categories in .desktop files that are not in this list are ignored */
-    category_definitions["All"]     = std::make_unique<WfMenuCategoryDefinition>("All", "applications-other");
-    category_definitions["Network"] = std::make_unique<WfMenuCategoryDefinition>("Internet",
+    category_list["All"]     = std::make_unique<WfMenuCategory>("All", "applications-other");
+    category_list["Network"] = std::make_unique<WfMenuCategory>("Internet",
         "applications-internet");
-    category_definitions["Education"] = std::make_unique<WfMenuCategoryDefinition>("Education",
+    category_list["Education"] = std::make_unique<WfMenuCategory>("Education",
         "applications-education");
-    category_definitions["Office"] = std::make_unique<WfMenuCategoryDefinition>("Office",
+    category_list["Office"] = std::make_unique<WfMenuCategory>("Office",
         "applications-office");
-    category_definitions["Development"] = std::make_unique<WfMenuCategoryDefinition>("Development",
+    category_list["Development"] = std::make_unique<WfMenuCategory>("Development",
         "applications-development");
-    category_definitions["Graphics"] = std::make_unique<WfMenuCategoryDefinition>("Graphics",
+    category_list["Graphics"] = std::make_unique<WfMenuCategory>("Graphics",
         "applications-graphics");
-    category_definitions["AudioVideo"] = std::make_unique<WfMenuCategoryDefinition>("Multimedia",
+    category_list["AudioVideo"] = std::make_unique<WfMenuCategory>("Multimedia",
         "applications-multimedia");
-    category_definitions["Game"] = std::make_unique<WfMenuCategoryDefinition>("Games",
+    category_list["Game"] = std::make_unique<WfMenuCategory>("Games",
         "applications-games");
-    category_definitions["Science"] = std::make_unique<WfMenuCategoryDefinition>("Science",
+    category_list["Science"] = std::make_unique<WfMenuCategory>("Science",
         "applications-science");
-    category_definitions["Settings"] = std::make_unique<WfMenuCategoryDefinition>("Settings",
+    category_list["Settings"] = std::make_unique<WfMenuCategory>("Settings",
         "preferences-desktop");
-    category_definitions["System"] = std::make_unique<WfMenuCategoryDefinition>("System",
+    category_list["System"] = std::make_unique<WfMenuCategory>("System",
         "applications-system");
-    category_definitions["Utility"] = std::make_unique<WfMenuCategoryDefinition>("Accessories",
+    category_list["Utility"] = std::make_unique<WfMenuCategory>("Accessories",
         "applications-utilities");
-    category_definitions["Hidden"] = std::make_unique<WfMenuCategoryDefinition>("Other Desktops",
+    category_list["Hidden"] = std::make_unique<WfMenuCategory>("Other Desktops",
         "user-desktop");
 
     output->toggle_menu_signal().connect(sigc::mem_fun(this, &WayfireMenu::toggle_menu));

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -114,7 +114,7 @@ WfMenuMenuItem::WfMenuMenuItem(WayfireMenu *_menu, Glib::RefPtr<Gio::DesktopAppI
         menu_item->set_label(m_app_info->get_action_name(action));
         menu_item->show();
         menu_item->signal_activate().connect(
-            [this, action] () 
+            [this, action] ()
         {
             m_app_info->launch_action(action);
             menu->hide_menu();
@@ -134,25 +134,25 @@ WfMenuMenuItem::WfMenuMenuItem(WayfireMenu *_menu, Glib::RefPtr<Gio::DesktopAppI
     event_box->signal_button_release_event().connect(
         [this] (GdkEventButton *ev) -> bool
     {
-        if (ev->button == GDK_BUTTON_PRIMARY && ev->type == GDK_BUTTON_RELEASE)
+        if ((ev->button == GDK_BUTTON_PRIMARY) && (ev->type == GDK_BUTTON_RELEASE))
         {
             on_click();
         }
-        if (m_has_actions && ev->button == GDK_BUTTON_SECONDARY && ev->type == GDK_BUTTON_RELEASE)
+        if (m_has_actions && (ev->button == GDK_BUTTON_SECONDARY) && (ev->type == GDK_BUTTON_RELEASE))
         {
-            if(menu->menu_list)
+            if (menu->menu_list)
             {
                 m_action_menu.popup_at_widget(this, Gdk::GRAVITY_NORTH_EAST, Gdk::GRAVITY_NORTH_WEST, NULL);
             } else
             {
                 m_action_menu.popup_at_widget(this, Gdk::GRAVITY_SOUTH, Gdk::GRAVITY_NORTH, NULL);
             }
+
             return true;
         }
 
         return false;
     });
-
 }
 
 void WfMenuMenuItem::on_click()
@@ -254,7 +254,7 @@ void WayfireMenu::load_menu_item(AppInfo app_info)
     loaded_apps.insert({name, exec});
 
     /* Check if this has a 'OnlyShownIn' for a different desktop env
-     *  If so, we throw it in a pile at the bottom just to be safe */
+    *  If so, we throw it in a pile at the bottom just to be safe */
     if (!desktop_app_info->get_show_in("wayfire"))
     {
         add_category_app("Hidden", desktop_app_info);
@@ -284,6 +284,7 @@ void WayfireMenu::add_category_app(std::string category, Glib::RefPtr<Gio::Deskt
             allowed = true;
         }
     }
+
     if (!allowed)
     {
         return;
@@ -301,7 +302,7 @@ void WayfireMenu::populate_menu_categories()
     }
 
     // Iterate allowed categories in order
-    for (auto category: category_order)
+    for (auto category : category_order)
     {
         if (category_definitions.count(category) == 1)
         {
@@ -323,7 +324,7 @@ void WayfireMenu::populate_menu_categories()
 
 void WayfireMenu::populate_menu_items(std::string category)
 {
-    // Ensure the flowbox is empty
+    /* Ensure the flowbox is empty */
     for (auto child : flowbox.get_children())
     {
         gtk_widget_destroy(GTK_WIDGET(child->gobj()));
@@ -802,12 +803,13 @@ void WayfireMenu::init(Gtk::HBox *container)
         [this] (GdkEventKey *ev) -> bool
     {
         /* It has string value, send it to searchbox
-         * This quickly filters navigation keys out*/
+        *  This quickly filters navigation keys out*/
         std::string input = ev->string;
         if (input.length() > 0)
         {
             return this->search_box.inject(ev);
         }
+
         /* Continue with normal event processing */
         return false;
     });

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -702,6 +702,7 @@ void WayfireMenu::refresh()
     {
         category_definition->items.clear();
     }
+
     for (auto child : flowbox.get_children())
     {
         gtk_widget_destroy(GTK_WIDGET(child->gobj()));

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -18,7 +18,7 @@
 #define MAX_LAUNCHER_NAME_LENGTH 11
 const std::string default_icon = ICONDIR "/wayfire.png";
 
-WfMenuCategoryDefinition::WfMenuCategoryDefinition(std::string _name, std::string _icon_name):
+WfMenuCategoryDefinition::WfMenuCategoryDefinition(std::string _name, std::string _icon_name) :
     name(_name), icon_name(_icon_name)
 {}
 
@@ -138,6 +138,7 @@ WfMenuMenuItem::WfMenuMenuItem(WayfireMenu *_menu, Glib::RefPtr<Gio::DesktopAppI
         {
             on_click();
         }
+
         if (m_has_actions && (ev->button == GDK_BUTTON_SECONDARY) && (ev->type == GDK_BUTTON_RELEASE))
         {
             if (menu->menu_list)
@@ -306,7 +307,7 @@ void WayfireMenu::populate_menu_categories()
     {
         if (category_definitions.count(category) == 1)
         {
-            if (items[category].size() > 0 )
+            if (items[category].size() > 0)
             {
                 auto icon_name = category_definitions[category]->get_icon_name();
                 auto name = category_definitions[category]->get_name();
@@ -803,7 +804,7 @@ void WayfireMenu::init(Gtk::HBox *container)
         [this] (GdkEventKey *ev) -> bool
     {
         /* It has string value, send it to searchbox
-        *  This quickly filters navigation keys out*/
+         * This quickly filters navigation keys out */
         std::string input = ev->string;
         if (input.length() > 0)
         {

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -256,7 +256,7 @@ void WayfireMenu::load_menu_item(AppInfo app_info)
 
     /* Check if this has a 'OnlyShownIn' for a different desktop env
     *  If so, we throw it in a pile at the bottom just to be safe */
-    if (!desktop_app_info->get_show_in("wayfire"))
+    if (!desktop_app_info->should_show())
     {
         add_category_app("Hidden", desktop_app_info);
         return;

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -15,10 +15,10 @@
 class WayfireMenu;
 using AppInfo = Glib::RefPtr<Gio::AppInfo>;
 
-class WfMenuCategoryDefinition
+class WfMenuCategory
 {
   public:
-    WfMenuCategoryDefinition(std::string name, std::string icon_name);
+    WfMenuCategory(std::string name, std::string icon_name);
     std::string get_name();
     std::string get_icon_name();
     std::vector<Glib::RefPtr<Gio::DesktopAppInfo>> items;
@@ -157,7 +157,7 @@ class WayfireMenu : public WayfireWidget
     /* loaded_apps is a list of the already-opened applications + their execs,
      * so that we don't show duplicate entries */
     std::set<std::pair<std::string, std::string>> loaded_apps;
-    std::unordered_map<std::string, std::unique_ptr<WfMenuCategoryDefinition>> category_definitions;
+    std::unordered_map<std::string, std::unique_ptr<WfMenuCategory>> category_list;
     std::string category = "All";
     std::vector<std::string> category_order = {
         "All", "Network", "Education", "Office", "Development", "Graphics", "AudioVideo", "Game", "Science",

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -21,6 +21,7 @@ class WfMenuCategoryDefinition
     WfMenuCategoryDefinition(std::string name, std::string icon_name);
     std::string get_name();
     std::string get_icon_name();
+    std::vector<Glib::RefPtr<Gio::DesktopAppInfo>> items;
 
   private:
     std::string name;
@@ -156,7 +157,6 @@ class WayfireMenu : public WayfireWidget
     /* loaded_apps is a list of the already-opened applications + their execs,
      * so that we don't show duplicate entries */
     std::set<std::pair<std::string, std::string>> loaded_apps;
-    std::unordered_map<std::string, std::vector<Glib::RefPtr<Gio::DesktopAppInfo>>> items;
     std::unordered_map<std::string, std::unique_ptr<WfMenuCategoryDefinition>> category_definitions;
     std::string category = "All";
     std::vector<std::string> category_order = {

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -44,10 +44,10 @@ class WfMenuCategoryButton : public Gtk::Button
     void on_click();
 };
 
-class WfMenuMenuItem : public Gtk::HBox
+class WfMenuMenuItem : public Gtk::FlowBoxChild
 {
   public:
-    WfMenuMenuItem(WayfireMenu *menu, AppInfo app);
+    WfMenuMenuItem(WayfireMenu *menu, Glib::RefPtr<Gio::DesktopAppInfo> app);
 
     bool matches(Glib::ustring text);
     bool fuzzy_match(Glib::ustring text);
@@ -56,12 +56,16 @@ class WfMenuMenuItem : public Gtk::HBox
   private:
     WayfireMenu *menu;
     Gtk::Box m_left_pad, m_right_pad;
-    Gtk::Button m_button;
+    Gtk::HBox m_padding_box;
     Gtk::VBox m_button_box;
+    Gtk::HBox m_list_box;
     Gtk::Image m_image;
     Gtk::Label m_label;
+    Gtk::Menu m_action_menu;
 
-    AppInfo m_app_info;
+    bool m_has_actions = false;
+
+    Glib::RefPtr<Gio::DesktopAppInfo> m_app_info;
     void on_click();
 };
 
@@ -106,6 +110,12 @@ class WayfireLogoutUI
     void on_cancel_click();
 };
 
+class WayfireMenuInjectionEntry: public Gtk::Entry
+{
+  public:
+  bool inject(GdkEventKey *ev);
+};
+
 class WayfireMenu : public WayfireWidget
 {
     WayfireOutput *output;
@@ -117,7 +127,7 @@ class WayfireMenu : public WayfireWidget
     Gtk::VBox category_box;
     Gtk::Separator separator;
     Gtk::Image main_image;
-    Gtk::Entry search_box;
+    WayfireMenuInjectionEntry search_box;
     Gtk::FlowBox flowbox;
     Gtk::Button logout_button;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
@@ -159,11 +169,14 @@ class WayfireMenu : public WayfireWidget
     WfOption<std::string> menu_icon{"panel/menu_icon"};
     WfOption<int> menu_size{"panel/launchers_size"};
     WfOption<int> menu_min_category_width{"panel/menu_min_category_width"};
-    WfOption<int> menu_min_content_width{"panel/menu_min_content_width"};
     WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
+    WfOption<bool> menu_show_categories{"panel/menu_show_categories"};
     void update_popover_layout();
     void create_logout_ui();
     void on_logout_click();
+    void key_press_search();
+    void select_first_flowbox_item();
+    void set_default_to_selection();
 
   public:
     void init(Gtk::HBox *container) override;
@@ -173,6 +186,9 @@ class WayfireMenu : public WayfireWidget
     void hide_menu();
     void refresh();
     void set_category(std::string category);
+    WfOption<bool> menu_list{"panel/menu_list"};
+    WfOption<int> menu_min_content_width{"panel/menu_min_content_width"};
+
     WayfireMenu(WayfireOutput *output)
     {
         this->output = output;

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -15,7 +15,7 @@
 class WayfireMenu;
 using AppInfo = Glib::RefPtr<Gio::AppInfo>;
 
-class WfMenuCategoryDefinition 
+class WfMenuCategoryDefinition
 {
   public:
     WfMenuCategoryDefinition(std::string name, std::string icon_name);
@@ -34,7 +34,7 @@ class WfMenuCategoryButton : public Gtk::Button
 
   private:
     WayfireMenu *menu;
-    Gtk::HBox  m_box;
+    Gtk::HBox m_box;
     Gtk::Label m_label;
     Gtk::Image m_image;
 
@@ -110,10 +110,10 @@ class WayfireLogoutUI
     void on_cancel_click();
 };
 
-class WayfireMenuInjectionEntry: public Gtk::Entry
+class WayfireMenuInjectionEntry : public Gtk::Entry
 {
   public:
-  bool inject(GdkEventKey *ev);
+    bool inject(GdkEventKey *ev);
 };
 
 class WayfireMenu : public WayfireWidget
@@ -158,9 +158,10 @@ class WayfireMenu : public WayfireWidget
     std::set<std::pair<std::string, std::string>> loaded_apps;
     std::unordered_map<std::string, std::vector<Glib::RefPtr<Gio::DesktopAppInfo>>> items;
     std::unordered_map<std::string, std::unique_ptr<WfMenuCategoryDefinition>> category_definitions;
-    std::string category="All";
+    std::string category = "All";
     std::vector<std::string> category_order = {
-      "All", "Network", "Education", "Office", "Development", "Graphics", "AudioVideo", "Game", "Science", "Settings", "System", "Utility", "Hidden"
+        "All", "Network", "Education", "Office", "Development", "Graphics", "AudioVideo", "Game", "Science",
+        "Settings", "System", "Utility", "Hidden"
     };
 
     WfOption<std::string> menu_logout_command{"panel/menu_logout_command"};

--- a/wf-shell.ini.example
+++ b/wf-shell.ini.example
@@ -99,10 +99,19 @@ network_icon_invert_color = 1
 # whether to colour the wifi signal strength
 network_status_use_color = yes
 
+# Show a list of application categories in menu
+menu_show_categories = false
+
+# Show application icons in a list view
+# false shows them as a grid
+menu_list = false
 
 # Configuration for the menu widget
 # whether to enable fuzzy search in the menu
 menu_fuzzy_search = 1
+
+# Minimum width for category list. Shares height with content Below
+menu_min_category_width = 200
 
 # Minimum width and height for the contents of the menu.
 # Can be useful for small screens and/or high DPI scaling.


### PR DESCRIPTION
Options added:
- Application icons in list form `panel/menu_list`
- Menu shows application categories `panel/menu_show_categories`
- Categories width `panel/menu_min_category_width`

New Menu Features:
- Categories to the left of application list
- Keyboard navigation of applications & categories
- Right click an application to choose between alternative actions
- Changing search term selects first item in list
- Categories hidden if no applications exist for it

Commits include work done for a different PR merged here and then reverted as the patch was unrelated.