### PR TITLE
gtk-utils: set icon changes

### DIFF
--- a/src/util/gtk-utils.cpp
+++ b/src/util/gtk-utils.cpp
@@ -89,12 +89,15 @@ void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
         pbuff = icon_theme->load_icon(icon_name, scaled_size, Gtk::ICON_LOOKUP_FORCE_SIZE)
             ->scale_simple(scaled_size, scaled_size, Gdk::INTERP_BILINEAR);
     }
+
     /* Get from filesystem if necessary */
-    if (!pbuff){
+    if (!pbuff)
+    {
         pbuff = load_icon_pixbuf_safe(icon_name, scaled_size);
     }
 
-    if (!pbuff){
+    if (!pbuff)
+    {
         return;
     }
 

--- a/src/util/gtk-utils.cpp
+++ b/src/util/gtk-utils.cpp
@@ -98,7 +98,14 @@ void set_image_icon(Gtk::Image& image, std::string icon_name, int size,
 
     if (!pbuff)
     {
-        return;
+        if (icon_theme->lookup_icon("image-missing", scaled_size))
+        {
+            pbuff = icon_theme->load_icon("image-missing", scaled_size, Gtk::ICON_LOOKUP_FORCE_SIZE)
+                ->scale_simple(scaled_size, scaled_size, Gdk::INTERP_BILINEAR);
+        } else
+        {
+            return;
+        }
     }
 
     if (options.invert)


### PR DESCRIPTION
gtk-utils: set_image_icon use both theme and filesystem
gtk-utils: set_image_icon stores at double necessary scale to allow unblurred scaling