### PR TITLE
window-list: cpu usage fix

### DIFF
--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -397,6 +397,7 @@ class WayfireToplevel::impl
         {
             return;
         }
+
         this->max_width = width;
         if (max_width == 0)
         {

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -392,7 +392,8 @@ class WayfireToplevel::impl
         return preferred_width;
     }
 
-    void refresh_contents(){
+    void refresh_contents()
+    {
         if (max_width == 0)
         {
             this->button.set_size_request(-1, -1);

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -119,7 +119,7 @@ class WayfireToplevel::impl
             sigc::mem_fun(this, &WayfireToplevel::impl::on_drag_update));
         drag_gesture->signal_drag_end().connect_notify(
             sigc::mem_fun(this, &WayfireToplevel::impl::on_drag_end));
-
+        button.show_all();
         this->window_list = window_list;
     }
 
@@ -359,8 +359,12 @@ class WayfireToplevel::impl
     {
         this->title = title;
         button.set_tooltip_text(title);
+        label.set_text(title);
 
-        set_max_width(max_width);
+        /* Force a refresh for new title contents */
+        int size = max_width;
+        max_width = 0;
+        set_max_width(size);
     }
 
     Glib::ustring shorten_title(int show_chars)
@@ -393,7 +397,7 @@ class WayfireToplevel::impl
 
     void set_max_width(int width)
     {
-        if (width == this->max_width)
+        if (width > 0 && width == this->max_width)
         {
             return;
         }

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -397,7 +397,7 @@ class WayfireToplevel::impl
 
     void set_max_width(int width)
     {
-        if (width > 0 && width == this->max_width)
+        if ((width > 0) && (width == this->max_width))
         {
             return;
         }

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -393,6 +393,9 @@ class WayfireToplevel::impl
 
     void set_max_width(int width)
     {
+        if (width == this->max_width){
+            return;
+        }
         this->max_width = width;
         if (max_width == 0)
         {

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -393,7 +393,8 @@ class WayfireToplevel::impl
 
     void set_max_width(int width)
     {
-        if (width == this->max_width){
+        if (width == this->max_width)
+        {
             return;
         }
         this->max_width = width;

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -361,10 +361,7 @@ class WayfireToplevel::impl
         button.set_tooltip_text(title);
         label.set_text(title);
 
-        /* Force a refresh for new title contents */
-        int size = max_width;
-        max_width = 0;
-        set_max_width(size);
+        refresh_contents();
     }
 
     Glib::ustring shorten_title(int show_chars)
@@ -395,14 +392,7 @@ class WayfireToplevel::impl
         return preferred_width;
     }
 
-    void set_max_width(int width)
-    {
-        if ((width > 0) && (width == this->max_width))
-        {
-            return;
-        }
-
-        this->max_width = width;
+    void refresh_contents(){
         if (max_width == 0)
         {
             this->button.set_size_request(-1, -1);
@@ -410,7 +400,7 @@ class WayfireToplevel::impl
             return;
         }
 
-        this->button.set_size_request(width, -1);
+        this->button.set_size_request(max_width, -1);
 
         int show_chars = 0;
         for (show_chars = title.length(); show_chars > 0; show_chars--)
@@ -423,6 +413,17 @@ class WayfireToplevel::impl
         }
 
         label.set_text(shorten_title(show_chars));
+    }
+
+    void set_max_width(int width)
+    {
+        if ((width > 0) && (width == this->max_width))
+        {
+            return;
+        }
+
+        this->max_width = width;
+        refresh_contents();
     }
 
     uint32_t get_state()


### PR DESCRIPTION
Quick check to avoid recalculating widget size on a loop when the window-list is over-full.

fixes #250 