### PR TITLE
window-list: remove width calculations and allow GTK to deal with button sizes

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -288,14 +288,17 @@ class WayfirePanel::impl
             {
                 should_expand = true;
             }
+
             container.push_back(std::move(widget));
         }
+
         GtkPackType pack_type;
         gboolean old_expand;
         guint old_padding;
-        gtk_box_query_child_packing((GtkBox*)content_box.gobj(), (GtkWidget*)box.gobj(), &old_expand, &old_expand, &old_padding, &pack_type);
-        gtk_box_set_child_packing((GtkBox*)content_box.gobj(), (GtkWidget*)box.gobj(), should_expand, should_expand, old_padding, pack_type);
-
+        gtk_box_query_child_packing((GtkBox*)content_box.gobj(),
+            (GtkWidget*)box.gobj(), &old_expand, &old_expand, &old_padding, &pack_type);
+        gtk_box_set_child_packing((GtkBox*)content_box.gobj(),
+            (GtkWidget*)box.gobj(), should_expand, should_expand, old_padding, pack_type);
     }
 
     WfOption<std::string> left_widgets_opt{"panel/widgets_left"};

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -139,6 +139,11 @@ class WayfirePanel::impl
         left_box.get_style_context()->add_class("left");
         center_box.get_style_context()->add_class("center");
         right_box.get_style_context()->add_class("right");
+
+        left_box.set_hexpand(false);
+        center_box.set_hexpand(false);
+        right_box.set_hexpand(false);
+
         content_box.pack_start(left_box, false, false);
         content_box.pack_end(right_box, false, false);
         if (!center_box.get_children().empty())
@@ -268,6 +273,7 @@ class WayfirePanel::impl
         const auto lock_notification_daemon = Daemon::Instance();
         container.clear();
         auto widgets = tokenize(list);
+        bool should_expand = false;
         for (auto widget_name : widgets)
         {
             auto widget = widget_from_name(widget_name);
@@ -278,8 +284,18 @@ class WayfirePanel::impl
 
             widget->widget_name = widget_name;
             widget->init(&box);
+            if (widget_name == "window-list")
+            {
+                should_expand = true;
+            }
             container.push_back(std::move(widget));
         }
+        GtkPackType pack_type;
+        gboolean old_expand;
+        guint old_padding;
+        gtk_box_query_child_packing((GtkBox*)content_box.gobj(), (GtkWidget*)box.gobj(), &old_expand, &old_expand, &old_padding, &pack_type);
+        gtk_box_set_child_packing((GtkBox*)content_box.gobj(), (GtkWidget*)box.gobj(), should_expand, should_expand, old_padding, pack_type);
+
     }
 
     WfOption<std::string> left_widgets_opt{"panel/widgets_left"};

--- a/src/panel/widgets/command-output.cpp
+++ b/src/panel/widgets/command-output.cpp
@@ -76,12 +76,12 @@ WfCommandOutputButtons::CommandOutput::CommandOutput(const std::string & name,
 
     if ((icon_position == "right") || (icon_position == "bottom"))
     {
-        box.pack_start(main_label);
-        box.pack_start(icon);
+        box.pack_start(main_label, false, false);
+        box.pack_start(icon, false, false);
     } else
     {
-        box.pack_start(icon);
-        box.pack_start(main_label);
+        box.pack_start(icon, false, false);
+        box.pack_start(main_label, false, false);
     }
 
     if (icon_name.empty())

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -444,7 +444,7 @@ void WayfireNetworkInfo::handle_config_reload()
     {
         if (!status.get_parent())
         {
-            button_content.pack_start(status);
+            button_content.pack_start(status, Gtk::PACK_SHRINK);
             button_content.show_all();
         }
     }

--- a/src/panel/widgets/separator.cpp
+++ b/src/panel/widgets/separator.cpp
@@ -10,6 +10,6 @@ WayfireSeparator::WayfireSeparator(int pixels)
 void WayfireSeparator::init(Gtk::HBox *container)
 {
     separator.get_style_context()->add_class("separator");
-    container->pack_start(separator);
+    container->pack_start(separator, Gtk::PACK_SHRINK);
     separator.show_all();
 }

--- a/src/panel/widgets/spacing.cpp
+++ b/src/panel/widgets/spacing.cpp
@@ -8,6 +8,6 @@ WayfireSpacing::WayfireSpacing(int pixels)
 void WayfireSpacing::init(Gtk::HBox *container)
 {
     box.get_style_context()->add_class("spacing");
-    container->pack_start(box);
+    container->pack_start(box, Gtk::PACK_SHRINK);
     box.show_all();
 }

--- a/src/panel/widgets/tray/tray.cpp
+++ b/src/panel/widgets/tray/tray.cpp
@@ -15,7 +15,7 @@ void WayfireStatusNotifier::add_item(const Glib::ustring & service)
     }
 
     items.emplace(service, service);
-    icons_hbox.pack_start(items.at(service));
+    icons_hbox.pack_start(items.at(service), Gtk::PACK_SHRINK);
     icons_hbox.show_all();
 }
 

--- a/src/panel/widgets/window-list/toplevel.hpp
+++ b/src/panel/widgets/window-list/toplevel.hpp
@@ -27,7 +27,6 @@ class WayfireToplevel
     WayfireToplevel(WayfireWindowList *window_list, zwlr_foreign_toplevel_handle_v1 *handle);
 
     uint32_t get_state();
-    void set_width(int pixels);
     zwlr_foreign_toplevel_handle_v1 *get_parent();
     void set_parent(zwlr_foreign_toplevel_handle_v1*);
     std::vector<zwlr_foreign_toplevel_handle_v1*>& get_children();

--- a/src/panel/widgets/window-list/window-list.hpp
+++ b/src/panel/widgets/window-list/window-list.hpp
@@ -82,7 +82,6 @@ class WayfireWindowList : public WayfireWidget
   private:
     void on_draw(const Cairo::RefPtr<Cairo::Context>&);
 
-    void set_button_width(int width);
     int get_default_button_width();
     int get_target_button_width();
 };


### PR DESCRIPTION
Changes `expand` `fill` and `hexpand` very liberally across the entire panel.

reloading widget lists sets or unsets expand & fill for the container to allow space to propagate to window-list

Major difference is that the ellipsis  cannot be removed when there are too many open windows.