### PR TITLE
wf-dock: improve finding icon for some GNOME apps

### DIFF
--- a/src/dock/toplevel-icon.cpp
+++ b/src/dock/toplevel-icon.cpp
@@ -239,8 +239,10 @@ Icon get_from_desktop_app_info(std::string app_id)
         "/usr/share/applications/",
         "/usr/share/applications/kde/",
         "/usr/share/applications/org.kde.",
+        "/usr/share/applications/org.gnome.",
         "/usr/local/share/applications/",
         "/usr/local/share/applications/org.kde.",
+        "/usr/local/share/applications/org.gnome.",
     };
 
     std::vector<std::string> app_id_variations = {

--- a/src/dock/toplevel-icon.cpp
+++ b/src/dock/toplevel-icon.cpp
@@ -248,7 +248,10 @@ Icon get_from_desktop_app_info(std::string app_id)
     std::vector<std::string> app_id_variations = {
         app_id,
         tolower(app_id),
+        tolower(app_id),
     };
+    // e.g. org.gnome.Evince.desktop
+    app_id_variations[2][0] = std::toupper(app_id_variations[2][0]);
 
     std::vector<std::string> suffixes = {
         "",


### PR DESCRIPTION
This is a much more limited attempt than #82 

Running on Ubuntu 24.04, this fixes finding icons for at least gedit (org.gnome.gedit), evince (org.gnome.Evince) and devhelp (org.gnome.Devhelp).

Let me know if moving this to a common util (with wf-panel) is still desired.