### PR TITLE
panel: show new toplevels as inactive by default

### DIFF
--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -63,6 +63,7 @@ class WayfireToplevel::impl
         button_contents.set_halign(Gtk::ALIGN_START);
         button.add(button_contents);
         button.set_tooltip_text("none");
+        set_state(0); // will set the appropriate button style
 
         button.signal_clicked().connect_notify(
             sigc::mem_fun(this, &WayfireToplevel::impl::on_clicked));


### PR DESCRIPTION
I realized that currently, the panel's window list implementation assumes that a newly opened toplevel is always "active". If this is not true (i.e. a toplevel opens, but is not focused, e.g. using the option from https://github.com/WayfireWM/wayfire/pull/2627), then the panel will display two active toplevels:

![current_double_active](https://github.com/user-attachments/assets/7a504463-b8f9-4285-8aa9-8830fac2bb07)

This PR fixes it by setting the state to inactive by default until a "state" event is received. This results in correctly only one toplevel displayed as active:

![no_default_active](https://github.com/user-attachments/assets/18d7265e-c7ff-4204-a587-6901239031a0)
