### PR TITLE
clock: update syntax for gtk4

### DIFF
--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -1,5 +1,4 @@
 #include <glibmm.h>
-#include <iostream>
 #include "clock.hpp"
 
 void WayfireClock::init(Gtk::Box *container)
@@ -8,7 +7,7 @@ void WayfireClock::init(Gtk::Box *container)
     button->get_style_context()->add_class("clock");
     button->set_child(label);
     button->show();
-    label.set_justify(Gtk::JUSTIFY_CENTER);
+    label.set_justify(Gtk::Justification::CENTER);
     label.show();
 
     update_label();


### PR DESCRIPTION
Accidentally merged a PR for the gtk3 version which doesn't compile anymore in gtk4, this PR fixes it.
