### PR TITLE
Fixed erronious option name in wp-mixer widget class definition

### DIFF
--- a/src/panel/widgets/wp-mixer/wp-mixer.hpp
+++ b/src/panel/widgets/wp-mixer/wp-mixer.hpp
@@ -28,7 +28,7 @@ class WayfireWpMixer : public WayfireWidget
 
     Gtk::Image main_image;
 
-    WfOption<double> timeout{"panel/wp_display_timeout"};
+    WfOption<double> timeout{"panel/wp_popup_timeout"};
 
     void on_volume_value_changed();
     bool on_popover_timeout(int timer);


### PR DESCRIPTION
Currently, the mixer widget looks for the wp_display_timeout option, which was changed before merging. My huge bad, i guess i forgot to stage this change.