### PR TITLE
panel: Fix wp-mixer interactions with autohide

### DIFF
--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -11,8 +11,8 @@ class WayfireVolume : public WayfireWidget
 {
     Gtk::Image main_image;
     WayfireAnimatedScale volume_scale;
-    Gtk::Button button;
-    Gtk::Popover popover;
+    std::unique_ptr<WayfireMenuButton> button;
+    Gtk::Popover *popover;
 
     WfOption<double> timeout{"panel/volume_display_timeout"};
     WfOption<double> scroll_sensitivity{"panel/volume_scroll_sensitivity"};


### PR DESCRIPTION
Switched from a manually managed popover and gtk button to a WayfireMenuButton to keep the panel out when the widget is in use and autohide is enabled. Used to retract in use, leading to it being hardly usable at times.