### PR TITLE
panel: Make reloading ipc widgets more robust

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -92,7 +92,6 @@ class WayfirePanel::impl
         gtk_layer_set_margin(window->gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, 0);
 
         window->present();
-        init_widgets();
         init_layout();
     }
 
@@ -211,7 +210,7 @@ class WayfirePanel::impl
 
         if (name == "language")
         {
-            if (WayfireIPC::get_instance()->connected)
+            if (get_ipc_server_instance()->connected)
             {
                 return Widget(new WayfireLanguage());
             } else
@@ -224,7 +223,7 @@ class WayfirePanel::impl
 
         if (name == "workspace-switcher")
         {
-            if (WayfireIPC::get_instance()->connected)
+            if (get_ipc_server_instance()->connected)
             {
                 return Widget(new WayfireWorkspaceSwitcher(output));
             } else
@@ -306,32 +305,6 @@ class WayfirePanel::impl
     WfOption<std::string> left_widgets_opt{"panel/widgets_left"};
     WfOption<std::string> right_widgets_opt{"panel/widgets_right"};
     WfOption<std::string> center_widgets_opt{"panel/widgets_center"};
-    void init_widgets()
-    {
-        left_widgets_opt.set_callback([=] ()
-        {
-            reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
-        });
-        right_widgets_opt.set_callback([=] ()
-        {
-            reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
-        });
-        center_widgets_opt.set_callback([=] ()
-        {
-            reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
-            if (center_box.get_children().empty())
-            {
-                content_box.unset_center_widget();
-            } else
-            {
-                content_box.set_center_widget(center_box);
-            }
-        });
-
-        reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
-        reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
-        reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
-    }
 
   public:
     impl(WayfireOutput *output) : output(output)
@@ -366,6 +339,44 @@ class WayfirePanel::impl
             w->handle_config_reload();
         }
     }
+
+    WayfirePanelApp *panel_app;
+    void set_panel_app(WayfirePanelApp *panel_app)
+    {
+        this->panel_app = panel_app;
+    }
+
+    void init_widgets()
+    {
+        left_widgets_opt.set_callback([=] ()
+        {
+            reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
+        });
+        right_widgets_opt.set_callback([=] ()
+        {
+            reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
+        });
+        center_widgets_opt.set_callback([=] ()
+        {
+            reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
+            if (center_box.get_children().empty())
+            {
+                content_box.unset_center_widget();
+            } else
+            {
+                content_box.set_center_widget(center_box);
+            }
+        });
+
+        reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
+        reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
+        reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
+    }
+
+    std::shared_ptr<WayfireIPC> get_ipc_server_instance()
+    {
+        return panel_app->get_ipc_server_instance();
+    }
 };
 
 WayfirePanel::WayfirePanel(WayfireOutput *output) : pimpl(new impl(output))
@@ -383,7 +394,17 @@ Gtk::Window& WayfirePanel::get_window()
 
 void WayfirePanel::handle_config_reload()
 {
-    return pimpl->handle_config_reload();
+    pimpl->handle_config_reload();
+}
+
+void WayfirePanel::init_widgets()
+{
+    pimpl->init_widgets();
+}
+
+void WayfirePanel::set_panel_app(WayfirePanelApp *panel_app)
+{
+    pimpl->set_panel_app(panel_app);
 }
 
 class WayfirePanelApp::impl
@@ -429,6 +450,18 @@ void WayfirePanelApp::on_activate()
     new CssFromConfigFont("panel/battery_font", ".battery {", "}");
     new CssFromConfigFont("panel/clock_font", ".clock {", "}");
     new CssFromConfigFont("panel/weather_font", ".weather {", "}");
+
+    ipc_server = WayfireIPC::get_instance();
+    for (auto& p : priv->panels)
+    {
+        p.second->set_panel_app(this);
+        p.second->init_widgets();
+    }
+}
+
+std::shared_ptr<WayfireIPC> WayfirePanelApp::get_ipc_server_instance()
+{
+    return ipc_server;
 }
 
 void WayfirePanelApp::handle_new_output(WayfireOutput *output)

--- a/src/panel/panel.hpp
+++ b/src/panel/panel.hpp
@@ -9,7 +9,9 @@
 #include "css-config.hpp"
 #include "giomm/application.h"
 #include "wf-shell-app.hpp"
+#include "wf-ipc.hpp"
 
+class WayfirePanelApp;
 class WayfirePanel
 {
   public:
@@ -18,6 +20,9 @@ class WayfirePanel
     wl_surface *get_wl_surface();
     Gtk::Window& get_window();
     void handle_config_reload();
+    void init_widgets();
+    void set_panel_app(WayfirePanelApp *panel_app);
+    std::shared_ptr<WayfireIPC> get_ipc_server_instance();
 
   private:
     class impl;
@@ -42,6 +47,8 @@ class WayfirePanelApp : public WayfireShellApp
     void handle_output_removed(WayfireOutput *output) override;
     void on_config_reload() override;
     void reload_css();
+    std::shared_ptr<WayfireIPC> get_ipc_server_instance();
+    std::shared_ptr<WayfireIPC> ipc_server;
 
   private:
     WayfirePanelApp();

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -4,10 +4,19 @@
 
 #include <wf-option-wrap.hpp>
 
+#include "panel.hpp"
 #include "workspace-switcher.hpp"
 
 void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
 {
+    ipc_client = WayfirePanelApp::get().get_ipc_server_instance()->create_client();
+
+    if (!ipc_client)
+    {
+        std::cerr << "Failed to connect to ipc. (are ipc and ipc-rules plugins loaded?)";
+        return;
+    }
+
     box.add_css_class("workspace-switcher");
     box.add_css_class("flat");
 
@@ -901,13 +910,16 @@ void WayfireWorkspaceSwitcher::grid_on_event(wf::json_t data)
 WayfireWorkspaceSwitcher::WayfireWorkspaceSwitcher(WayfireOutput *output)
 {
     this->output_name = output->monitor->get_connector();
-    ipc_client = WayfireIPC::get_instance()->create_client();
     switcher_box.set_vexpand(false);
     switcher_box.set_valign(Gtk::Align::CENTER);
 }
 
 WayfireWorkspaceSwitcher::~WayfireWorkspaceSwitcher()
 {
-    ipc_client->unsubscribe(this);
+    if (ipc_client)
+    {
+        ipc_client->unsubscribe(this);
+    }
+
     clear_box();
 }

--- a/src/util/wf-ipc.cpp
+++ b/src/util/wf-ipc.cpp
@@ -313,6 +313,12 @@ void WayfireIPC::unsubscribe(IIPCSubscriber *subscriber)
 
 std::shared_ptr<IPCClient> WayfireIPC::create_client()
 {
+    if (!connected)
+    {
+        std::cerr << "Failed to create ipc client" << std::endl;
+        return nullptr;
+    }
+
     auto client = new IPCClient(next_client_id, shared_from_this());
     clients[next_client_id++] = client;
 


### PR DESCRIPTION
This effectively fixes a crash when unloading the last ipc widget. It also makes it so there is only one master WayfireIPC instance.