### PR TITLE
panel: do not rely on option reload to set center widget

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -371,6 +371,14 @@ class WayfirePanel::impl
         reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
         reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
         reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
+
+        if (center_box.get_children().empty())
+        {
+            content_box.unset_center_widget();
+        } else
+        {
+            content_box.set_center_widget(center_box);
+        }
     }
 
     std::shared_ptr<WayfireIPC> get_ipc_server_instance()


### PR DESCRIPTION
We must check that there are center widgets and set the panel center widget in init_widgets without relying on option reload to do this for us.

Authored by: Scott Moreau <oreaus@gmail.com>
"whoa, I just looked out the window and saw an exploding kitten!"