### PR TITLE
Make menu layer override when showing popup optional

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -189,6 +189,11 @@
 		<default>42</default>
 		<min>0</min>
 	</option>
+	<option name="menu_force_show_popup" type="bool">
+		<_short>Force showing the menu popup</_short>
+		<_long>Show the menu popup over other windows, even if it and the panel would be hidden otherwise.</_long>
+		<default>true</default>
+	</option>
 	<option name="menu_min_category_width" type="int">
 		<_short>Menu Minimum Category Width</_short>
 		<default>200</default>

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -518,9 +518,11 @@ void WayfireMenu::on_popover_shown()
     set_category("All");
     flowbox.unselect_all();
 
-    Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
-
-    gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    if (force_show_popup.value())
+    {
+        Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
+        gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    }
 }
 
 bool WayfireMenu::update_icon()
@@ -615,8 +617,14 @@ void WayfireMenu::setup_popover_layout()
         return false;
     }, false));
     button->get_popover()->add_controller(typing_gesture);
+
     signals.push_back(button->get_popover()->signal_closed().connect([=] ()
     {
+        if (!force_show_popup.value())
+        {
+            return;
+        }
+
         Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
         WfOption<std::string> panel_layer{"panel/layer"};
 

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -176,6 +176,7 @@ class WayfireMenu : public WayfireWidget
     WfOption<bool> fuzzy_search_enabled{"panel/menu_fuzzy_search"};
     WfOption<std::string> panel_position{"panel/position"};
     WfOption<std::string> menu_icon{"panel/menu_icon"};
+    WfOption<bool> force_show_popup{"panel/menu_force_show_popup"};
     WfOption<int> menu_min_category_width{"panel/menu_min_category_width"};
     WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
     WfOption<bool> menu_show_categories{"panel/menu_show_categories"};


### PR DESCRIPTION
Currently, when the menu widget pops out it’s popover, it sets the panel layer to GTK_LAYER_SHELL_LAYER_OVERLAY. I am pretty sure it doesn’t really have a place here, as a user desiring this would just set the panel itself to overlay, and as someone who has it in the TOP layer, i just find it aggravating when it pops up.