### PR TITLE
Restore window-list middle click to close option

### DIFF
--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -147,7 +147,7 @@ class WayfireToplevel::impl
                 }
 
                 ignore_next_click = false;
-            } else if (butt == 2 && middle_click_close.value())
+            } else if ((butt == 2) && middle_click_close.value())
             {
                 zwlr_foreign_toplevel_handle_v1_close(handle);
             } else if (butt == 3)


### PR DESCRIPTION
Option was ignored and windows were always closed upon middle click.