### PR TITLE
panel: window-list: Fix random crashes

### DIFF
--- a/src/panel/widgets/window-list/window-list.cpp
+++ b/src/panel/widgets/window-list/window-list.cpp
@@ -14,7 +14,10 @@ static void handle_manager_toplevel(void *data, zwlr_foreign_toplevel_manager_v1
 }
 
 static void handle_manager_finished(void *data, zwlr_foreign_toplevel_manager_v1 *manager)
-{}
+{
+    zwlr_foreign_toplevel_manager_v1_stop(manager);
+    zwlr_foreign_toplevel_manager_v1_destroy(manager);
+}
 
 zwlr_foreign_toplevel_manager_v1_listener toplevel_manager_v1_impl = {
     .toplevel = handle_manager_toplevel,


### PR DESCRIPTION
This fixes the case where some actions cause the panel to die, with the Gdk wayland error message "Error reading events from display: Invalid argument".