### PR TITLE
panel : restore launchers spacing config and add tray spacing config

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -85,6 +85,7 @@
 	<option name="launchers_spacing" type="int">
 		<_short>Launchers Spacing</_short>
 		<default>4</default>
+		<min>0</min>
 	</option>
 	<option name="launchers_size" type="int">
 		<_short>Launchers Icon Size</_short>
@@ -398,6 +399,11 @@
 	<option name="tray_icon_size" type="int">
 		<_short>Default Icon Size</_short>
 		<default>0</default>
+		<min>0</min>
+	</option>
+	<option name="tray_spacing" type="int">
+		<_short>Space between tray icons</_short>
+		<default>5</default>
 		<min>0</min>
 	</option>
 	<option name="tray_menu_on_middle_click" type="bool">

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -155,6 +155,11 @@ void WayfireLaunchers::init(Gtk::Box *container)
     handle_config_reload();
 }
 
+void WayfireLaunchers::update_layout()
+{
+    box.set_spacing(spacing);
+}
+
 void WayfireLaunchers::handle_config_reload()
 {
     for (auto child : box.get_children())
@@ -167,4 +172,6 @@ void WayfireLaunchers::handle_config_reload()
     {
         box.append(l->button);
     }
+
+    update_layout();
 }

--- a/src/panel/widgets/launchers.hpp
+++ b/src/panel/widgets/launchers.hpp
@@ -32,8 +32,11 @@ class WayfireLaunchers : public WayfireWidget
     launcher_container launchers;
     launcher_container get_launchers_from_config();
 
+    WfOption<int> spacing{"panel/launchers_spacing"};
+
   public:
     virtual void init(Gtk::Box *container);
+    void update_layout();
     virtual void handle_config_reload();
     virtual ~WayfireLaunchers()
     {}

--- a/src/panel/widgets/tray/tray.cpp
+++ b/src/panel/widgets/tray/tray.cpp
@@ -3,7 +3,11 @@
 void WayfireStatusNotifier::init(Gtk::Box *container)
 {
     icons_box.add_css_class("tray");
-    icons_box.set_spacing(5);
+    update_layout();
+    icons_box.set_halign(Gtk::Align::FILL);
+    icons_box.set_valign(Gtk::Align::FILL);
+    icons_box.set_expand(true);
+    icons_box.set_homogeneous(true);
     container->append(icons_box);
 }
 
@@ -27,4 +31,14 @@ void WayfireStatusNotifier::remove_item(const Glib::ustring & service)
 
     icons_box.remove(items.at(service));
     items.erase(service);
+}
+
+void WayfireStatusNotifier::update_layout()
+{
+    icons_box.set_spacing(spacing);
+}
+
+void WayfireStatusNotifier::handle_config_reload()
+{
+    update_layout();
 }

--- a/src/panel/widgets/tray/tray.hpp
+++ b/src/panel/widgets/tray/tray.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "item.hpp"
+#include "wf-option-wrap.hpp"
 #include "widgets/tray/host.hpp"
 
 #include <widget.hpp>
@@ -12,6 +13,11 @@ class WayfireStatusNotifier : public WayfireWidget
 
     Gtk::Box icons_box;
     std::map<Glib::ustring, StatusNotifierItem> items;
+
+    WfOption<int> spacing{"panel/tray_spacing"};
+
+    void update_layout();
+    void handle_config_reload();
 
   public:
     void init(Gtk::Box *container) override;


### PR DESCRIPTION
« Spacing » being the amount of space between each element, as both widgets use boxes and contain multiple icons.

Launchers’s config was being ignored and tray didn’t have one, always using the magic number 5.