### PR TITLE
Smooth live window preview frames

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,8 @@ dbusmenu_gtk = dependency('dbusmenu-glib-0.4')
 xkbregistry = dependency('xkbregistry')
 json = subproject('wf-json').get_variable('wfjson')
 openssl = dependency('openssl')
+gbm = dependency('gbm', required: get_option('live-previews-dmabuf'))
+drm = dependency('libdrm', required: get_option('live-previews-dmabuf'))
 
 if get_option('wayland-logout') == true
 	wayland_logout = subproject('wayland-logout')
@@ -40,6 +42,10 @@ endif
 if get_option('weather') == true
 	subproject('owf')
 	add_project_arguments('-DHAVE_WEATHER=1', language: 'cpp')
+endif
+
+if gbm.found() and drm.found() and not get_option('live-previews-dmabuf').disabled()
+	add_project_arguments('-DHAVE_DMABUF=1', language: 'cpp')
 endif
 
 if libpulse.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,9 @@ option(
     value: false,
     description: 'Install weather widgets and open-weather-fetch systemd service',
 )
+option(
+    'live-previews-dmabuf',
+    type: 'feature',
+    value: 'auto',
+    description: 'Enable live window preview tooltips when hovering over window-list buttons in wf-panel'
+)

--- a/proto/meson.build
+++ b/proto/meson.build
@@ -20,6 +20,10 @@ client_protocols = [
     wayfire.get_pkgconfig_variable('pkgdatadir') / 'unstable' / 'wayfire-shell-unstable-v2.xml',
 ]
 
+if gbm.found() and drm.found() and not get_option('live-previews-dmabuf').disabled()
+    client_protocols += [join_paths(wl_protocol_dir, 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml')]
+endif
+
 wl_protos_src = []
 wl_protos_headers = []
 

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -65,6 +65,12 @@ else
   message('Weather disabled, weather widgets and owf service not included.')
 endif
 
+if gbm.found() and drm.found() and not get_option('live-previews-dmabuf').disabled()
+  deps += [gbm, drm]
+else
+  message('Development packages for gbm and drm are required to enable live window preview tooltips in wf-panel.')
+endif
+
 executable(
   'wf-panel',
   ['panel.cpp'] + widget_sources,

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -45,6 +45,31 @@ static int create_anon_file(off_t size)
     return fd;
 }
 
+#ifdef HAVE_DMABUF
+static void dmabuf_created(void *data, struct zwp_linux_buffer_params_v1*,
+    struct wl_buffer *wl_buffer)
+{
+    TooltipMedia *tooltip_media = (TooltipMedia*)data;
+
+    tooltip_media->buffer = wl_buffer;
+    zwlr_screencopy_frame_v1_copy(tooltip_media->frame, tooltip_media->buffer);
+}
+
+static void dmabuf_failed(void *data, struct zwp_linux_buffer_params_v1*)
+{
+    TooltipMedia *tooltip_media = (TooltipMedia*)data;
+
+    std::cerr << "Failed to create dmabuf, trying shm" << std::endl;
+    tooltip_media->window_list->live_previews_dmabuf = false;
+}
+
+static const struct zwp_linux_buffer_params_v1_listener params_listener =
+{
+    .created = dmabuf_created,
+    .failed  = dmabuf_failed,
+};
+#endif // HAVE_DMABUF
+
 void handle_frame_buffer(void *data,
     struct zwlr_screencopy_frame_v1 *zwlr_screencopy_frame_v1,
     uint32_t format,
@@ -53,6 +78,12 @@ void handle_frame_buffer(void *data,
     uint32_t stride)
 {
     TooltipMedia *tooltip_media = (TooltipMedia*)data;
+
+    if (tooltip_media->window_list->live_previews_dmabuf)
+    {
+        tooltip_media->shm_data = nullptr;
+        return;
+    }
 
     size_t size = width * height * int(stride / width);
 
@@ -110,12 +141,63 @@ void handle_frame_ready(void *data,
 
     tooltip_media->request_next_frame();
 
-    if (!tooltip_media->shm_data || !tooltip_media->size)
+#ifdef HAVE_DMABUF
+    if (tooltip_media->window_list->live_previews_dmabuf && tooltip_media->bo)
+    {
+        uint32_t stride = 0;
+        tooltip_media->map_data    = nullptr;
+        tooltip_media->dmabuf_data = gbm_bo_map(tooltip_media->bo,
+            0, 0, tooltip_media->buffer_width, tooltip_media->buffer_height,
+            GBM_BO_TRANSFER_READ, &stride, &tooltip_media->map_data);
+
+        if (!tooltip_media->dmabuf_data)
+        {
+            perror("Failed to map bo");
+            std::cerr << "Trying shm" << std::endl;
+            tooltip_media->window_list->live_previews_dmabuf = false;
+            return;
+        }
+
+        if (tooltip_media->bo && tooltip_media->map_data)
+        {
+            gbm_bo_unmap(tooltip_media->bo, tooltip_media->map_data);
+            tooltip_media->map_data = nullptr;
+        }
+
+        tooltip_media->buffer_stride = stride;
+        tooltip_media->size = tooltip_media->buffer_height * tooltip_media->buffer_stride;
+    }
+
+#endif // HAVE_DMABUF
+
+    if ((!tooltip_media->shm_data
+#ifdef HAVE_DMABUF
+         && !tooltip_media->dmabuf_data
+#endif // HAVE_DMABUF
+        ) || !tooltip_media->size)
     {
         return;
     }
 
-    auto bytes = Glib::Bytes::create(tooltip_media->shm_data, tooltip_media->size);
+    std::shared_ptr<Glib::Bytes> bytes = 0;
+    size_t size = tooltip_media->buffer_height * tooltip_media->buffer_stride;
+    if (tooltip_media->shm_data)
+    {
+        bytes = Glib::Bytes::create(tooltip_media->shm_data, size);
+    }
+
+#ifdef HAVE_DMABUF
+    else if (tooltip_media->dmabuf_data)
+    {
+        bytes = Glib::Bytes::create(tooltip_media->dmabuf_data, size);
+        tooltip_media->dmabuf_data = nullptr;
+    }
+#endif // HAVE_DMABUF
+
+    if (!bytes)
+    {
+        return;
+    }
 
     auto builder = Gdk::MemoryTextureBuilder::create();
     builder->set_bytes(bytes);
@@ -140,12 +222,86 @@ void handle_frame_damage(void*,
     uint32_t)
 {}
 
-void handle_frame_linux_dmabuf(void*,
-    struct zwlr_screencopy_frame_v1*,
-    uint32_t,
-    uint32_t,
-    uint32_t)
-{}
+void handle_frame_linux_dmabuf(void *data,
+    struct zwlr_screencopy_frame_v1 *frame,
+    uint32_t format,
+    uint32_t width,
+    uint32_t height)
+{
+#ifdef HAVE_DMABUF
+    TooltipMedia *tooltip_media = (TooltipMedia*)data;
+
+    if (!tooltip_media->window_list->live_previews_dmabuf)
+    {
+        return;
+    }
+
+    tooltip_media->buffer_width  = width;
+    tooltip_media->buffer_height = height;
+
+    if (!tooltip_media->buffer)
+    {
+        if (tooltip_media->bo)
+        {
+            if (tooltip_media->buffer)
+            {
+                wl_buffer_destroy(tooltip_media->buffer);
+                tooltip_media->buffer = nullptr;
+            }
+
+            if (tooltip_media->params)
+            {
+                zwp_linux_buffer_params_v1_destroy(tooltip_media->params);
+                tooltip_media->params = nullptr;
+            }
+
+            if (tooltip_media->bo)
+            {
+                gbm_bo_destroy(tooltip_media->bo);
+                tooltip_media->bo = nullptr;
+            }
+        }
+
+        const uint64_t modifier = 0; // DRM_FORMAT_MOD_LINEAR
+        tooltip_media->bo = gbm_bo_create_with_modifiers(tooltip_media->window_list->dmabuf_device,
+            tooltip_media->buffer_width,
+            tooltip_media->buffer_height, format, &modifier, 1);
+        if (!tooltip_media->bo)
+        {
+            tooltip_media->bo = gbm_bo_create(tooltip_media->window_list->dmabuf_device,
+                tooltip_media->buffer_width,
+                tooltip_media->buffer_height, format, GBM_BO_USE_LINEAR | GBM_BO_USE_RENDERING);
+        }
+
+        if (!tooltip_media->bo)
+        {
+            perror("Failed to create gbm bo");
+            std::cerr << "Trying shm" << std::endl;
+            tooltip_media->window_list->live_previews_dmabuf = false;
+            return;
+        }
+
+        tooltip_media->buffer_stride = gbm_bo_get_stride(tooltip_media->bo);
+
+        tooltip_media->params = zwp_linux_dmabuf_v1_create_params(tooltip_media->window_list->dmabuf);
+
+        uint64_t mod = gbm_bo_get_modifier(tooltip_media->bo);
+        zwp_linux_buffer_params_v1_add(tooltip_media->params,
+            gbm_bo_get_fd(tooltip_media->bo), 0,
+            gbm_bo_get_offset(tooltip_media->bo, 0),
+            gbm_bo_get_stride(tooltip_media->bo),
+            mod >> 32, mod & 0xffffffff);
+
+        zwp_linux_buffer_params_v1_add_listener(tooltip_media->params, &params_listener, tooltip_media);
+        zwp_linux_buffer_params_v1_create(tooltip_media->params, tooltip_media->buffer_width,
+            tooltip_media->buffer_height, format, 0);
+    } else
+    {
+        zwlr_screencopy_frame_v1_copy(frame, tooltip_media->buffer);
+    }
+
+#endif // HAVE_DMABUF
+}
 
 void handle_frame_buffer_done(void*, struct zwlr_screencopy_frame_v1*)
 {}
@@ -198,10 +354,13 @@ TooltipMedia::~TooltipMedia()
     if (this->frame)
     {
         zwlr_screencopy_frame_v1_destroy(this->frame);
-        this->frame = NULL;
     }
 
-    if (this->shm_data && this->size)
+    if (
+#ifdef HAVE_DMABUF
+        !this->window_list->live_previews_dmabuf &&
+#endif // HAVE_DMABUF
+        this->shm_data && this->size)
     {
         if (munmap(this->shm_data, this->size) < 0)
         {
@@ -209,8 +368,28 @@ TooltipMedia::~TooltipMedia()
         }
     }
 
-    this->shm_data = NULL;
-    this->size     = 0;
+    if (this->buffer)
+    {
+        wl_buffer_destroy(this->buffer);
+    }
+
+#ifdef HAVE_DMABUF
+    if (this->params)
+    {
+        zwp_linux_buffer_params_v1_destroy(this->params);
+    }
+
+    if (this->bo && this->map_data)
+    {
+        gbm_bo_unmap(this->bo, this->map_data);
+    }
+
+    if (this->bo)
+    {
+        gbm_bo_destroy(this->bo);
+    }
+
+#endif // HAVE_DMABUF
 }
 
 class WayfireToplevel::impl
@@ -895,6 +1074,8 @@ class WayfireToplevel::impl
 
     ~impl()
     {
+        unset_tooltip_media();
+
         gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
 
         button_leave_signal.disconnect();

--- a/src/panel/widgets/window-list/toplevel.hpp
+++ b/src/panel/widgets/window-list/toplevel.hpp
@@ -12,6 +12,12 @@
 #include "wf-shell-app.hpp"
 #include "panel.hpp"
 
+#ifdef HAVE_DMABUF
+    #include <gbm.h>
+    #include <xf86drm.h>
+    #include <linux-dmabuf-unstable-v1-client-protocol.h>
+#endif // HAVE_DMABUF
+
 class WayfireWindowList;
 class WayfireWindowListBox;
 
@@ -25,17 +31,22 @@ enum WayfireToplevelState
 class TooltipMedia : public Gtk::Picture
 {
   public:
-    WayfireWindowList *window_list = NULL;
-    wl_shm *shm = NULL;
-    wl_buffer *buffer = NULL;
-    void *shm_data    = NULL;
-    char *screencopy_data = NULL;
-    zwlr_screencopy_frame_v1 *frame = NULL;
-
-    int buffer_width;
-    int buffer_height;
-    int buffer_stride;
+    WayfireWindowList *window_list = nullptr;
+    wl_shm *shm = nullptr;
+    wl_buffer *buffer = nullptr;
+    void *shm_data    = nullptr;
+    zwlr_screencopy_frame_v1 *frame = nullptr;
+    uint32_t buffer_width;
+    uint32_t buffer_height;
+    uint32_t buffer_stride;
     size_t size = 0;
+
+#ifdef HAVE_DMABUF
+    gbm_bo *bo = nullptr;
+    zwp_linux_buffer_params_v1 *params = nullptr;
+    void *dmabuf_data = nullptr;
+    void *map_data    = nullptr;
+#endif // HAVE_DMABUF
 
     TooltipMedia(WayfireWindowList *window_list);
     ~TooltipMedia();

--- a/src/panel/widgets/window-list/window-list.cpp
+++ b/src/panel/widgets/window-list/window-list.cpp
@@ -4,6 +4,10 @@
 
 #include "window-list.hpp"
 
+#ifdef HAVE_DMABUF
+    #include <fcntl.h>
+#endif // HAVE_DMABUF
+
 #define DEFAULT_SIZE_PC 0.1
 
 static void handle_manager_toplevel(void *data, zwlr_foreign_toplevel_manager_v1 *manager,
@@ -22,45 +26,6 @@ static void handle_manager_finished(void *data, zwlr_foreign_toplevel_manager_v1
 zwlr_foreign_toplevel_manager_v1_listener toplevel_manager_v1_impl = {
     .toplevel = handle_manager_toplevel,
     .finished = handle_manager_finished,
-};
-
-static void registry_add_object(void *data, wl_registry *registry, uint32_t name,
-    const char *interface, uint32_t version)
-{
-    WayfireWindowList *window_list = (WayfireWindowList*)data;
-
-    if (strcmp(interface, wl_output_interface.name) == 0)
-    {
-        wl_output *output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, version);
-        window_list->handle_new_wl_output(output);
-    } else if (strcmp(interface, wl_shm_interface.name) == 0)
-    {
-        window_list->shm = (wl_shm*)wl_registry_bind(registry, name, &wl_shm_interface, version);
-    } else if (strcmp(interface, zwlr_foreign_toplevel_manager_v1_interface.name) == 0)
-    {
-        auto zwlr_toplevel_manager = (zwlr_foreign_toplevel_manager_v1*)
-            wl_registry_bind(registry, name,
-            &zwlr_foreign_toplevel_manager_v1_interface,
-            version);
-        window_list->handle_toplevel_manager(zwlr_toplevel_manager);
-        zwlr_foreign_toplevel_manager_v1_add_listener(window_list->manager,
-            &toplevel_manager_v1_impl, window_list);
-        wl_display_roundtrip(window_list->display);
-    } else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) == 0)
-    {
-        window_list->screencopy_manager = (zwlr_screencopy_manager_v1*)wl_registry_bind(registry, name,
-            &zwlr_screencopy_manager_v1_interface,
-            version);
-    }
-}
-
-static void registry_remove_object(void *data, struct wl_registry *registry, uint32_t name)
-{}
-
-static struct wl_registry_listener registry_listener =
-{
-    &registry_add_object,
-    &registry_remove_object
 };
 
 void handle_output_geometry(void*,
@@ -118,6 +83,152 @@ static struct wl_output_listener output_listener =
     handle_output_description,
 };
 
+#ifdef HAVE_DMABUF
+static void dmabuf_feedback_done(void *data, struct zwp_linux_dmabuf_feedback_v1 *feedback)
+{
+    WayfireWindowList *window_list = (WayfireWindowList*)data;
+
+    zwp_linux_dmabuf_feedback_v1_destroy(feedback);
+    window_list->feedback = nullptr;
+}
+
+static void dmabuf_feedback_format_table(void*, struct zwp_linux_dmabuf_feedback_v1*,
+    int32_t fd, uint32_t)
+{
+    close(fd);
+}
+
+static void dmabuf_feedback_main_device(void *data, struct zwp_linux_dmabuf_feedback_v1*,
+    struct wl_array *device)
+{
+    WayfireWindowList *window_list = (WayfireWindowList*)data;
+
+    int drm_fd;
+    dev_t dev_id;
+    std::string drm_device_name;
+    memcpy(&dev_id, device->data, device->size);
+
+    drmDevice *dev = NULL;
+    if (drmGetDeviceFromDevId(dev_id, 0, &dev) != 0)
+    {
+        perror("Failed to get DRM device from dev id");
+        std::cerr << "Trying shm" << std::endl;
+        window_list->live_previews_dmabuf = false;
+        return;
+    }
+
+    if (dev->available_nodes & (1 << DRM_NODE_RENDER))
+    {
+        drm_device_name = dev->nodes[DRM_NODE_RENDER];
+    } else if (dev->available_nodes & (1 << DRM_NODE_PRIMARY))
+    {
+        drm_device_name = dev->nodes[DRM_NODE_PRIMARY];
+    }
+
+    drm_fd = open(drm_device_name.c_str(), O_RDWR);
+    if (drm_fd < 0)
+    {
+        perror("Failed to open drm device");
+        std::cerr << "Trying shm" << std::endl;
+        window_list->live_previews_dmabuf = false;
+        return;
+    }
+
+    window_list->dmabuf_device = gbm_create_device(drm_fd);
+    if (window_list->dmabuf_device == NULL)
+    {
+        close(drm_fd);
+        perror("Failed to create gbm device");
+        std::cerr << "Trying shm" << std::endl;
+        window_list->live_previews_dmabuf = false;
+        return;
+    }
+
+    std::cout << "Live previews using drm device node: \"" << drm_device_name << "\"" << std::endl;
+
+    drmFreeDevice(&dev);
+    close(drm_fd);
+}
+
+static void dmabuf_feedback_tranche_done(void*, struct zwp_linux_dmabuf_feedback_v1*)
+{}
+
+static void dmabuf_feedback_tranche_target_device(void*, struct zwp_linux_dmabuf_feedback_v1*,
+    struct wl_array*)
+{}
+
+static void dmabuf_feedback_tranche_formats(void*, struct zwp_linux_dmabuf_feedback_v1*,
+    struct wl_array*)
+{}
+
+static void dmabuf_feedback_tranche_flags(void*, struct zwp_linux_dmabuf_feedback_v1*,
+    uint32_t)
+{}
+
+static const struct zwp_linux_dmabuf_feedback_v1_listener dmabuf_feedback_listener = {
+    .done = dmabuf_feedback_done,
+    .format_table = dmabuf_feedback_format_table,
+    .main_device  = dmabuf_feedback_main_device,
+    .tranche_done = dmabuf_feedback_tranche_done,
+    .tranche_target_device = dmabuf_feedback_tranche_target_device,
+    .tranche_formats = dmabuf_feedback_tranche_formats,
+    .tranche_flags   = dmabuf_feedback_tranche_flags,
+};
+#endif // HAVE_DMABUF
+
+static void registry_add_object(void *data, wl_registry *registry, uint32_t name,
+    const char *interface, uint32_t version)
+{
+    WayfireWindowList *window_list = (WayfireWindowList*)data;
+
+    if (strcmp(interface, wl_output_interface.name) == 0)
+    {
+        wl_output *output = (wl_output*)wl_registry_bind(registry, name, &wl_output_interface, version);
+        window_list->handle_new_wl_output(output);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0)
+    {
+        window_list->shm = (wl_shm*)wl_registry_bind(registry, name, &wl_shm_interface, version);
+    } else if (strcmp(interface, zwlr_foreign_toplevel_manager_v1_interface.name) == 0)
+    {
+        auto zwlr_toplevel_manager = (zwlr_foreign_toplevel_manager_v1*)
+            wl_registry_bind(registry, name,
+            &zwlr_foreign_toplevel_manager_v1_interface,
+            version);
+        window_list->handle_toplevel_manager(zwlr_toplevel_manager);
+        zwlr_foreign_toplevel_manager_v1_add_listener(window_list->manager,
+            &toplevel_manager_v1_impl, window_list);
+        wl_display_roundtrip(window_list->display);
+    } else if (strcmp(interface, zwlr_screencopy_manager_v1_interface.name) == 0)
+    {
+        window_list->screencopy_manager = (zwlr_screencopy_manager_v1*)wl_registry_bind(registry, name,
+            &zwlr_screencopy_manager_v1_interface,
+            version);
+    }
+
+#ifdef HAVE_DMABUF
+    else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0)
+    {
+        window_list->dmabuf = (zwp_linux_dmabuf_v1*)wl_registry_bind(registry, name,
+            &zwp_linux_dmabuf_v1_interface, version);
+        if (window_list->dmabuf)
+        {
+            window_list->feedback = zwp_linux_dmabuf_v1_get_default_feedback(window_list->dmabuf);
+            zwp_linux_dmabuf_feedback_v1_add_listener(window_list->feedback, &dmabuf_feedback_listener,
+                window_list);
+        }
+    }
+#endif // HAVE_DMABUF
+}
+
+static void registry_remove_object(void *data, struct wl_registry *registry, uint32_t name)
+{}
+
+static struct wl_registry_listener registry_listener =
+{
+    &registry_add_object,
+    &registry_remove_object
+};
+
 void WayfireWindowList::destroy_window_list_live_preview_output()
 {
     if (this->window_list_live_preview_output)
@@ -161,10 +272,12 @@ void WayfireWindowList::live_window_previews_plugin_check()
             if (!this->live_window_previews_opt)
             {
                 std::cout << "Detected live-previews plugin is enabled but wf-shell configuration [panel] option 'live_window_previews' is set to 'false'." << std::endl;
-                this->enable_normal_tooltips_flag(true);
+                this->enable_normal_tooltips_flag(
+                    true);
             } else
             {
-                std::cout << "Enabling live window preview tooltips." << std::endl;
+                std::cout << "Enabling live window preview tooltips using " <<
+                    std::string(live_previews_dmabuf ? "dmabuf" : "shm") << " transfers." << std::endl;
                 this->enable_normal_tooltips_flag(false);
             }
         }
@@ -226,6 +339,12 @@ void WayfireWindowList::init(Gtk::Box *container)
         wl_registry_destroy(registry);
         return;
     }
+
+#ifdef HAVE_DMABUF
+    this->live_previews_dmabuf = this->dmabuf ? true : false;
+#else
+    this->live_previews_dmabuf = false;
+#endif // HAVE_DMABUF
 
     scrolled_window.add_css_class("window-list");
 
@@ -368,9 +487,31 @@ WayfireWindowList::WayfireWindowList(WayfireOutput *output)
 
 WayfireWindowList::~WayfireWindowList()
 {
+    /* Call the toplevels destructors first.
+     * This fixes a crash when a dmabuf tooltip is present
+     * when the window-list widget is unloaded. */
+    toplevels.clear();
+
     destroy_window_list_live_preview_output();
-    wl_registry_destroy(this->registry);
     wl_shm_destroy(this->shm);
     zwlr_foreign_toplevel_manager_v1_destroy(this->manager);
     zwlr_screencopy_manager_v1_destroy(this->screencopy_manager);
+#ifdef HAVE_DMABUF
+    if (this->dmabuf)
+    {
+        zwp_linux_dmabuf_v1_destroy(this->dmabuf);
+    }
+
+    if (this->feedback)
+    {
+        zwp_linux_dmabuf_feedback_v1_destroy(this->feedback);
+    }
+
+    if (this->dmabuf_device)
+    {
+        gbm_device_destroy(this->dmabuf_device);
+    }
+
+#endif
+    wl_registry_destroy(this->registry);
 }

--- a/src/panel/widgets/window-list/window-list.hpp
+++ b/src/panel/widgets/window-list/window-list.hpp
@@ -7,6 +7,10 @@
 #include "layout.hpp"
 #include "wf-ipc.hpp"
 
+#ifdef HAVE_DMABUF
+    #include <gbm.h>
+#endif // HAVE_DMABUF
+
 class WayfireWindowListOutput
 {
   public:
@@ -27,9 +31,9 @@ class WayfireWindowList : public Gtk::Box, public WayfireWidget, public IIPCSubs
 
     wl_display *display;
     wl_registry *registry;
-    wl_shm *shm;
-    zwlr_foreign_toplevel_manager_v1 *manager = NULL;
-    zwlr_screencopy_manager_v1 *screencopy_manager = NULL;
+    wl_shm *shm = nullptr;
+    zwlr_foreign_toplevel_manager_v1 *manager = nullptr;
+    zwlr_screencopy_manager_v1 *screencopy_manager = nullptr;
     WayfireOutput *output;
     Gtk::ScrolledWindow scrolled_window;
 
@@ -89,6 +93,13 @@ class WayfireWindowList : public Gtk::Box, public WayfireWidget, public IIPCSubs
     void live_window_previews_plugin_check();
     void enable_ipc(bool enable);
     bool live_window_previews_enabled();
+    bool live_previews_dmabuf = true;
+
+#ifdef HAVE_DMABUF
+    zwp_linux_dmabuf_feedback_v1 *feedback = nullptr;
+    zwp_linux_dmabuf_v1 *dmabuf = nullptr;
+    gbm_device *dmabuf_device   = nullptr;
+#endif // HAVE_DMABUF
 
   private:
     int get_default_button_width();


### PR DESCRIPTION
- Doesn't rely on Gtk::Picture ticks to drive the frame requests but instead waits until a frame has been processed
- Implements dmabuf live preview transfers
- Installed a meson feature option, so that gbm and drm dependencies are not required. In that case, it will still work using shm transfers.