### PR TITLE
panel: quickfix for tray segfaulting in failed start

### DIFF
--- a/src/panel/widgets/tray/watcher.cpp
+++ b/src/panel/widgets/tray/watcher.cpp
@@ -65,8 +65,17 @@ Watcher::~Watcher()
         Gio::DBus::unwatch_name(item_id);
     }
 
-    watcher_connection->unregister_object(dbus_object_id);
-    Gio::DBus::unown_name(dbus_name_id);
+    if (dbus_object_id)
+    {
+        watcher_connection->unregister_object(dbus_object_id);
+        dbus_object_id = 0;
+    }
+
+    if (dbus_name_id)
+    {
+        Gio::DBus::unown_name(dbus_name_id);
+        dbus_name_id = 0;
+    }
 }
 
 void Watcher::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection,

--- a/src/panel/widgets/tray/watcher.hpp
+++ b/src/panel/widgets/tray/watcher.hpp
@@ -34,8 +34,8 @@ class Watcher
   private:
     inline static std::weak_ptr<Watcher> instance;
 
-    guint dbus_name_id;
-    guint dbus_object_id;
+    guint dbus_name_id   = 0;
+    guint dbus_object_id = 0;
     Glib::RefPtr<Gio::DBus::Connection> watcher_connection;
 
     std::map<Glib::ustring, guint> sn_items_id;


### PR DESCRIPTION
Once again ran afoul of the segfault that happens when cleaning up after failing to create a WfOption because of missing metadata.
Niche, but it helps to see the real error.