### PR TITLE
utils : icons : introduce multiple icon possibilities with priorities

### DIFF
--- a/src/util/icon-select.cpp
+++ b/src/util/icon-select.cpp
@@ -1,12 +1,28 @@
+#include <gdkmm/display.h>
+#include <gtkmm/icontheme.h>
+
 #include "icon-select.hpp"
 
-std::string icon_from_range(std::map<double, std::string> icons, double value)
+std::string icon_from_range(std::map<double, std::vector<std::string>> icons, double value)
 {
     for (auto pair : icons)
     {
         if (value <= pair.first)
         {
-            return pair.second;
+            auto theme = Gtk::IconTheme::get_for_display(Gdk::Display::get_default());
+            if (!theme)
+            {
+                // let’s stick to standard icons in this case
+                return *pair.second.end();
+            }
+
+            for (auto name : pair.second)
+            {
+                if (theme->has_icon(name))
+                {
+                    return name;
+                }
+            }
         }
     }
 

--- a/src/util/icon-select.hpp
+++ b/src/util/icon-select.hpp
@@ -1,17 +1,21 @@
 #include <map>
+#include <vector>
 #include <string>
 #include <limits>
 
-std::string icon_from_range(std::map<double, std::string> icons, double value);
+std::string icon_from_range(std::map<double, std::vector<std::string>> icons, double value);
 
 // the number in the first term is the maximal value at which this icon will be shown
 // selection values of the tables are expected to be ordered from least to greatest
+// the vector of icons is the different possibilites of icons to show,
+// with the prefered one as the first. This is to be able to use non-standard icons
+// if they are present in the current theme, and fall back to a standard one if not.
 
-const std::map<double, std::string> volume_icons = {
-    {std::numeric_limits<double>::min(), "emblem-unreadable"},
-    {0.0, "audio-volume-muted"},
-    {0.33, "audio-volume-low"},
-    {0.66, "audio-volume-medium"},
-    {1.0, "audio-volume-high"},
-    {std::numeric_limits<double>::max(), "dialog-warning"}
+const std::map<double, std::vector<std::string>> volume_icons = {
+    {std::numeric_limits<double>::min(), {"emblem-unreadable"}},
+    {0.0, {"audio-volume-muted"}},
+    {0.33, {"audio-volume-low"}},
+    {0.66, {"audio-volume-medium"}},
+    {1.0, {"audio-volume-high"}},
+    {std::numeric_limits<double>::max(), {"audio-volume-high-danger", "dialog-warning"}}
 };


### PR DESCRIPTION
Icon selection can now safely use non-standard icons by setting a fallback to a standard one to use if the desired one is not available.