### PR TITLE
Don't use menubuttons where we don't want buttons

### DIFF
--- a/data/css/default.css
+++ b/data/css/default.css
@@ -24,11 +24,21 @@
 .wf-panel .battery label,
 .wf-panel .battery:hover label,
 .wf-panel .window-button label,
+.wf-panel .window-button image,
 .wf-panel .window-button:hover label,
 .wf-panel .tray-button,
 .wf-panel .tray-button:hover,
 .wf-panel .notification button {
     padding-left: 5px;
+}
+
+
+.wf-panel .window-button.activated {
+    background-color: #8883;
+}
+
+.wf-panel .window-button:hover {
+    background-color: #8882;
 }
 
 .wf-panel .battery overlay label {
@@ -94,7 +104,7 @@ text-shadow: 1px  1px 0 var(--bcol),
     background-color: #24283B;
     padding: 5px;
     margin: 5px;
-    border-radius: 3px; 
+    border-radius: 3px;
     color: #41A6B5;
 }
 
@@ -132,6 +142,15 @@ text-shadow: 1px  1px 0 var(--bcol),
     background-color: #00FFAA77;
     border: 1px solid #222;
 }
+
+.wf-panel .wf-menu.selected {
+    background-color:#8883;
+}
+
+.wf-panel .wf-menu:hover {
+    background-color: #8882;
+}
+
 .excellent {
     color: #00ff00;
 }

--- a/data/css/default.css
+++ b/data/css/default.css
@@ -24,11 +24,21 @@
 .wf-panel .battery label,
 .wf-panel .battery:hover label,
 .wf-panel .window-button label,
+.wf-panel .window-button image,
 .wf-panel .window-button:hover label,
 .wf-panel .tray-button,
 .wf-panel .tray-button:hover,
 .wf-panel .notification button {
     padding-left: 5px;
+}
+
+
+.wf-panel .window-button.activated {
+    background-color: #8883;
+}
+
+.wf-panel .window-button:hover {
+    background-color: #8882;
 }
 
 .wf-panel .battery overlay label {
@@ -94,7 +104,7 @@ text-shadow: 1px  1px 0 var(--bcol),
     background-color: #24283B;
     padding: 5px;
     margin: 5px;
-    border-radius: 3px; 
+    border-radius: 3px;
     color: #41A6B5;
 }
 
@@ -132,6 +142,15 @@ text-shadow: 1px  1px 0 var(--bcol),
     background-color: #00FFAA77;
     border: 1px solid #222;
 }
+
+.wf-panel .wf-menu.selected {
+    background-color:#8883;
+}
+
+.wf-panel .wf-menu:hover {
+    background-color: #8882;
+}
+
 .excellent>label {
     color: #00ff00;
 }

--- a/data/css/default.css
+++ b/data/css/default.css
@@ -100,7 +100,7 @@ text-shadow: 1px  1px 0 var(--bcol),
     min-width: 48px;
 }
 
-.wf-panel .language label {
+.wf-panel label.language {
     background-color: #24283B;
     padding: 5px;
     margin: 5px;

--- a/data/css/default.css
+++ b/data/css/default.css
@@ -10,12 +10,12 @@
 }
 
 .wf-panel .tray-button image,
-.wf-panel .launcher image {
+.wf-panel image.launcher{
     transition: 500ms linear;
     -gtk-icon-transform: scale(0.8);
 }
 
-.wf-panel .launcher:hover image,
+.wf-panel image.launcher:hover,
 .wf-panel .tray-button:hover image {
     transition: 500ms linear;
     -gtk-icon-transform: scale(1.2);

--- a/data/css/default.css
+++ b/data/css/default.css
@@ -1,14 +1,3 @@
-.wf-panel .launcher,
-.wf-panel .launcher:hover,
-.wf-panel .tray-button,
-.wf-panel .tray-button:hover {
-    background: unset;
-    border: unset;
-    box-shadow: unset;
-    padding-left: unset;
-    padding-right: unset;
-}
-
 .wf-panel .tray-button image,
 .wf-panel image.launcher{
     transition: 500ms linear;
@@ -18,9 +7,10 @@
 .wf-panel image.launcher:hover,
 .wf-panel .tray-button:hover image {
     transition: 500ms linear;
-    -gtk-icon-transform: scale(1.2);
+    -gtk-icon-transform: scale(1.0);
 }
 
+/* FIXME: Makes a bad assumption about LTR reading direction. */
 .wf-panel .battery label,
 .wf-panel .battery:hover label,
 .wf-panel .window-button label,
@@ -31,7 +21,6 @@
 .wf-panel .notification button {
     padding-left: 5px;
 }
-
 
 .wf-panel .window-button.activated {
     background-color: #8883;

--- a/data/css/panel-window-list-zoom-hover.css
+++ b/data/css/panel-window-list-zoom-hover.css
@@ -1,23 +1,23 @@
 /* Default size not-selected not-hovered */
-.wf-panel .window-button.flat image {
+.wf-panel .window-button image {
     transition: 500ms linear;
     -gtk-icon-transform: scale(1.0);
 }
 
 /* Double size not-selected hovered */
-.wf-panel .window-button.flat:hover image {
+.wf-panel .window-button:hover image {
     transition: 100ms linear;
     -gtk-icon-transform: scale(2.0);
 }
 
 /* +50% size selected not-hovered */
-.wf-panel .window-button image {
+.wf-panel .window-button.activated image {
     transition: 100ms linear;
     -gtk-icon-transform: scale(1.5);
 }
 
 /* Double size selected hovered */
-.wf-panel .window-button:hover image {
+.wf-panel .window-button.activated:hover image {
     transition: 100ms linear;
     -gtk-icon-transform: scale(2.0);
 }

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -75,6 +75,15 @@
 			<_name>Background</_name>
 		</desc>
 	</option>
+	<option name="force_show_popup" type="bool">
+		<_short>Force showing the popups</_short>
+		<_long>Show the popup over other windows, even if it and the panel would be hidden otherwise.</_long>
+		<default>true</default>
+	</option>
+	<option name="menus_change_motion" type="bool">
+		<_short>Change between open menu with mouse motion</_short>
+		<default>false</default>
+	</option>
 	<option name="background_color" type="string">
 		<_short>Background Color</_short>
 		<default>gtk_headerbar</default>
@@ -202,11 +211,6 @@
 		<_short>Menu Icon Size</_short>
 		<default>42</default>
 		<min>0</min>
-	</option>
-	<option name="menu_force_show_popup" type="bool">
-		<_short>Force showing the menu popup</_short>
-		<_long>Show the menu popup over other windows, even if it and the panel would be hidden otherwise.</_long>
-		<default>true</default>
 	</option>
 	<option name="menu_min_category_width" type="int">
 		<_short>Menu Minimum Category Width</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -122,6 +122,15 @@ If full_span is off, both sides of the panel will take the same amount of space,
 			<_name>Background</_name>
 		</desc>
 	</option>
+	<option name="force_show_popup" type="bool">
+		<_short>Force showing the popups</_short>
+		<_long>Show the popup over other windows, even if it and the panel would be hidden otherwise.</_long>
+		<default>true</default>
+	</option>
+	<option name="menus_change_motion" type="bool">
+		<_short>Change between open menu with mouse motion</_short>
+		<default>false</default>
+	</option>
 	<option name="background_color" type="string">
 		<_short>Background Color</_short>
 		<default>gtk_headerbar</default>
@@ -278,11 +287,6 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<_short>Space between menu items</_short>
 		<default>8</default>
 		<min>0</min>
-	</option>
-	<option name="menu_force_show_popup" type="bool">
-		<_short>Force showing the menu popup</_short>
-		<_long>Show the menu popup over other windows, even if it and the panel would be hidden otherwise.</_long>
-		<default>true</default>
 	</option>
 	<option name="menu_min_category_width" type="int">
 		<_short>Menu Minimum Category Width</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -387,7 +387,7 @@ If full_span is off, both sides of the panel will take the same amount of space,
 	<option name="mixer_popup_timeout" type="double">
 		<_short>Popup timeout</_short>
 		<default>2.5</default>
-		<min>0</min>
+		<min>0.1</min>
 	</option>
 	<option name="mixer_slider_length" type="int">
 		<_short>Slider length</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -430,6 +430,10 @@ If full_span is off, both sides of the panel will take the same amount of space,
 			<value>show_quick_target</value>
 			<_name>Show quick action target</_name>
 		</desc>
+		<desc>
+			<value>mute_quick_target</value>
+			<_name>Mute quick action target</_name>
+		</desc>
 	</option>
 	<option name="mixer_middle_click_action" type="string">
 		<_short>Middle click action</_short>

--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -31,7 +31,7 @@ void WayfireBackground::setup_window()
     gtk_layer_set_anchor(gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, true);
     gtk_layer_set_anchor(gobj(), GTK_LAYER_SHELL_EDGE_LEFT, true);
     gtk_layer_set_anchor(gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, true);
-    gtk_layer_set_keyboard_mode(gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+    gtk_layer_set_keyboard_mode(gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
 
     gtk_layer_set_exclusive_zone(gobj(), -1);
 

--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -23,7 +23,7 @@ class WfDock::impl
     std::unique_ptr<WayfireAutohidingWindow> window;
     wl_surface *_wl_surface;
     Gtk::FlowBox box;
-    std::unique_ptr<WayfireMenuButton> network_image;
+    std::unique_ptr<WayfireMenuWidget> network_image;
     std::unique_ptr<NetworkControlWidget> network_control;
     std::shared_ptr<NetworkManager> network_manager;
 

--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -14,6 +14,7 @@
 #include "network/manager.hpp"
 #include "network/network-widget.hpp"
 #include "network/network.hpp"
+#include "wf-popover.hpp"
 #include <css-config.hpp>
 
 

--- a/src/locker/plugin/volume.hpp
+++ b/src/locker/plugin/volume.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <memory>
 #include <gtkmm/button.h>
-#include <gtkmm/popover.h>
 #include <gtkmm/scale.h>
 #include <pulse/pulseaudio.h>
 

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -112,16 +112,20 @@ class WayfirePanel::impl
 
                 left_box.set_halign(Gtk::Align::END);
                 right_box.set_halign(Gtk::Align::START);
-                left_box.set_valign(Gtk::Align::CENTER);
-                right_box.set_valign(Gtk::Align::CENTER);
+                center_box.set_halign(Gtk::Align::CENTER);
+                left_box.set_valign(Gtk::Align::FILL);
+                right_box.set_valign(Gtk::Align::FILL);
+                center_box.set_valign(Gtk::Align::FILL);
             } else
             {
                 content_box.set_size_request(-1, (std::max(lnat, rnat) * 2) + mnat);
 
-                left_box.set_halign(Gtk::Align::CENTER);
-                right_box.set_halign(Gtk::Align::CENTER);
+                left_box.set_halign(Gtk::Align::FILL);
+                right_box.set_halign(Gtk::Align::FILL);
+                center_box.set_halign(Gtk::Align::FILL);
                 left_box.set_valign(Gtk::Align::END);
                 right_box.set_valign(Gtk::Align::START);
+                center_box.set_valign(Gtk::Align::CENTER);
             }
         } else
         {
@@ -134,14 +138,14 @@ class WayfirePanel::impl
             {
                 left_box.set_halign(Gtk::Align::START);
                 right_box.set_halign(Gtk::Align::END);
-                left_box.set_valign(Gtk::Align::CENTER);
-                right_box.set_valign(Gtk::Align::CENTER);
+                left_box.set_valign(Gtk::Align::FILL);
+                right_box.set_valign(Gtk::Align::FILL);
             } else
             {
                 left_box.set_valign(Gtk::Align::START);
                 right_box.set_valign(Gtk::Align::END);
-                left_box.set_halign(Gtk::Align::CENTER);
-                right_box.set_halign(Gtk::Align::CENTER);
+                left_box.set_halign(Gtk::Align::FILL);
+                right_box.set_halign(Gtk::Align::FILL);
             }
         }
     }
@@ -174,8 +178,6 @@ class WayfirePanel::impl
 
         content_box.set_hexpand(true);
         content_box.set_vexpand(true);
-        center_box.set_halign(Gtk::Align::CENTER);
-        center_box.set_valign(Gtk::Align::CENTER);
 
         window->set_child(content_box);
     }

--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -139,14 +139,14 @@ void WayfireBatteryInfo::update_details()
         description += ", " + uint_to_time(time_to_empty.get()) + " remaining";
     }
 
-    button.set_tooltip_text(
+    box.set_tooltip_text(
         get_device_type_description(type.get()) + description);
 
     if (status_opt.value() == BATTERY_STATUS_PERCENT)
     {
         label.set_text(percentage_string);
         overlay.remove_overlay(label);
-        button_box.append(label);
+        box.append(label);
     } else if (status_opt.value() == BATTERY_STATUS_FULL)
     {
         label.set_text(description);
@@ -156,14 +156,14 @@ void WayfireBatteryInfo::update_details()
             overlay.remove_overlay(label);
         }
 
-        button_box.append(label);
+        box.append(label);
     } else if (status_opt.value() == BATTERY_STATUS_OVERLAY)
     {
         label.set_text(percentage_string);
-        auto children = button_box.get_children();
+        auto children = box.get_children();
         if (std::count(children.begin(), children.end(), &label))
         {
-            button_box.remove(label);
+            box.remove(label);
         }
 
         overlay.add_overlay(label);
@@ -231,10 +231,10 @@ void WayfireBatteryInfo::update_layout()
 
     if (panel_position.value() == PANEL_POSITION_LEFT or panel_position.value() == PANEL_POSITION_RIGHT)
     {
-        button_box.set_orientation(Gtk::Orientation::VERTICAL);
+        box.set_orientation(Gtk::Orientation::VERTICAL);
     } else
     {
-        button_box.set_orientation(Gtk::Orientation::HORIZONTAL);
+        box.set_orientation(Gtk::Orientation::HORIZONTAL);
     }
 }
 
@@ -252,22 +252,20 @@ void WayfireBatteryInfo::init(Gtk::Box *container)
         return;
     }
 
-    button_box.append(overlay);
+    box.append(overlay);
     overlay.set_child(icon);
     icon.add_css_class("widget-icon");
-    button.add_css_class("battery");
-    button.add_css_class("flat");
+    box.add_css_class("battery");
 
     status_opt.set_callback([=] () { update_details(); });
 
     update_details();
     update_icon();
 
-    container->append(button);
-    button_box.set_spacing(5);
+    container->append(box);
+    box.set_spacing(5);
 
-    button.set_child(button_box);
-    button.property_scale_factor().signal_changed()
+    icon.property_scale_factor().signal_changed()
         .connect(sigc::mem_fun(*this, &WayfireBatteryInfo::update_icon));
 
     update_layout();

--- a/src/panel/widgets/battery.hpp
+++ b/src/panel/widgets/battery.hpp
@@ -28,9 +28,8 @@ class WayfireBatteryInfo : public WayfireWidget
 
     sigc::connection btn_sig, disp_dev_sig;
 
-    Gtk::Button button;
     Gtk::Label label;
-    Gtk::Box button_box;
+    Gtk::Box box;
     Gtk::Overlay overlay;
 
     Gtk::Image icon;

--- a/src/panel/widgets/brightness/brightness.cpp
+++ b/src/panel/widgets/brightness/brightness.cpp
@@ -86,10 +86,9 @@ void WfLightControl::update_parent_icon()
     if (parent->ctrl_this_display.get() == this)
     {
         parent->update_icon();
-        if (parent->popup_on_change && !parent->button->get_active())
+        if (parent->popup_on_change)
         {
-            parent->button->activate();
-            parent->check_set_popover_timeout();
+            parent->button->popup_timed(parent->popup_timeout);
         }
     }
 }
@@ -121,15 +120,11 @@ WayfireBrightness::~WayfireBrightness()
 
 void WayfireBrightness::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel");
-    button->add_css_class("widget-icon");
-    button->add_css_class("brightness");
-    button->add_css_class("flat");
-    button->get_children()[0]->add_css_class("flat");
+    button = std::make_unique<WayfireMenuWidget>("panel", "brightness");
     button->set_child(icon);
     button->show();
-    popover = button->get_popover();
-    popover->set_autohide(false);
+    button->open_on(1);
+    button->add_css_class("widget-icon");
 
     // layout
     box.set_orientation(Gtk::Orientation::VERTICAL);
@@ -196,8 +191,7 @@ void WayfireBrightness::init(Gtk::Box *container)
     scroll_gesture->set_flags(Gtk::EventControllerScroll::Flags::VERTICAL);
     button->add_controller(scroll_gesture);
 
-    popover->set_child(box);
-    popover->get_style_context()->add_class("brightness-popover");
+    button->set_popup_child(box);
 
     container->append(*button);
 
@@ -293,24 +287,4 @@ void WayfireBrightness::update_icon()
     }
 
     icon.set_from_icon_name(ICON(ctrl_this_display->get_scale_target_value()));
-}
-
-bool WayfireBrightness::on_popover_timeout(int timer)
-{
-    popover_timeout.disconnect();
-    popover->popdown();
-    return false;
-}
-
-void WayfireBrightness::check_set_popover_timeout()
-{
-    popover_timeout.disconnect();
-
-    popover_timeout = Glib::signal_timeout().connect(sigc::bind(sigc::mem_fun(*this,
-        &WayfireBrightness::on_popover_timeout), 0), popup_timeout * 1000);
-}
-
-void WayfireBrightness::cancel_popover_timeout()
-{
-    popover_timeout.disconnect();
 }

--- a/src/panel/widgets/brightness/brightness.hpp
+++ b/src/panel/widgets/brightness/brightness.hpp
@@ -1,3 +1,4 @@
+#include "wf-popover.hpp"
 #include <gtkmm.h>
 #include <memory>
 #include <sigc++/connection.h>
@@ -133,24 +134,22 @@ class WayfireBrightness : public WayfireWidget
     WayfireOutput *output;
 
     Gtk::Image icon;
-    Gtk::Popover *popover;
     Gtk::Box box, display_box, other_box;
     Gtk::Label display_label, other_label;
     Gtk::Separator disp_othr_sep;
     sigc::connection popover_timeout;
 
-    WfOption<double> popup_timeout{"panel/brightness_popup_timeout"};
     WfOption<int> spacing{"panel/brightness_spacing"};
 
-    bool on_popover_timeout(int timer);
     void hide_unused();
 
   public:
     WayfireBrightness(WayfireOutput *output);
     ~WayfireBrightness();
 
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
 
+    WfOption<double> popup_timeout{"panel/brightness_popup_timeout"};
     WfOption<double> scroll_sensitivity{"panel/brightness_scroll_sensitivity"};
     WfOption<bool> invert_scroll{"panel/brightness_invert_scroll"};
     WfOption<bool> popup_on_change{"panel/brightness_popup_on_change"};
@@ -158,9 +157,6 @@ class WayfireBrightness : public WayfireWidget
     std::shared_ptr<WfLightControl> ctrl_this_display;
 
     std::vector<std::shared_ptr<WfLightControl>> controls;
-
-    void check_set_popover_timeout();
-    void cancel_popover_timeout();
 
     void add_control(std::shared_ptr<WfLightControl> control);
     void rem_control(std::shared_ptr<WfLightControl> control);

--- a/src/panel/widgets/brightness/ddcutil.cpp
+++ b/src/panel/widgets/brightness/ddcutil.cpp
@@ -105,7 +105,6 @@ class WfLightDdcaControl : public WfLightControl
             std::thread(writevcp, this).detach();
         }
 
-        parent->cancel_popover_timeout();
         update_parent_icon();
 
         for (auto control : DdcaSurveillor::get().ref_to_controls[ref])

--- a/src/panel/widgets/brightness/sysfs.cpp
+++ b/src/panel/widgets/brightness/sysfs.cpp
@@ -82,7 +82,6 @@ class WfLightSysfsControl : public WfLightControl
 
         b_file.close();
 
-        parent->cancel_popover_timeout();
         update_parent_icon();
     }
 
@@ -148,8 +147,6 @@ class WfLightSysfsDbusSystemdControl : public WfLightSysfsControl
             params,
             "org.freedesktop.login1" // bus name
         );
-
-        parent->cancel_popover_timeout();
         update_parent_icon();
     }
 };

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -6,7 +6,7 @@ void WayfireClock::init(Gtk::Box *container)
     button = std::make_unique<WayfireMenuWidget>("panel", "clock");
     button->add_css_class("clock");
     button->append(label);
-    button->show();
+    button->open_on(1);
     label.set_justify(Gtk::Justification::CENTER);
     label.show();
 

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -3,7 +3,7 @@
 
 void WayfireClock::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel", "clock");
+    button = std::make_unique<WayfireMenuWidget>("panel", "clock");
     button->add_css_class("clock");
     button->append(label);
     button->show();
@@ -13,7 +13,7 @@ void WayfireClock::init(Gtk::Box *container)
     update_label();
 
     calendar.show();
-    button->set_popover_child(calendar);
+    button->set_popup_child(calendar);
     btn_sig = button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireClock::on_calendar_shown));
 

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -3,9 +3,9 @@
 
 void WayfireClock::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "clock");
     button->add_css_class("clock");
-    button->set_child(label);
+    button->append(label);
     button->show();
     label.set_justify(Gtk::Justification::CENTER);
     label.show();
@@ -13,10 +13,8 @@ void WayfireClock::init(Gtk::Box *container)
     update_label();
 
     calendar.show();
-    button->get_popover()->add_css_class("clock-popover");
-    button->get_children()[0]->add_css_class("flat");
-    button->get_popover()->set_child(calendar);
-    btn_sig = button->get_popover()->signal_show().connect(
+    button->set_popover_child(calendar);
+    btn_sig = button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireClock::on_calendar_shown));
 
     container->append(*button);

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -43,7 +43,7 @@ bool WayfireClock::update_label()
      * This could be circumvented with the modifiers the user passes to the
      * format string, * but to remove the requirement that the user does
      * something fancy, we just remove any leading spaces. */
-    int i = 0;
+    size_t i = 0;
     while (i < text.length() && text[i] == ' ')
     {
         i++;

--- a/src/panel/widgets/clock.hpp
+++ b/src/panel/widgets/clock.hpp
@@ -9,7 +9,7 @@ class WayfireClock : public WayfireWidget
 {
     Gtk::Label label;
     Gtk::Calendar calendar;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
 
     sigc::connection timeout, btn_sig;
     WfOption<std::string> format{"panel/clock_format"};

--- a/src/panel/widgets/language.cpp
+++ b/src/panel/widgets/language.cpp
@@ -26,13 +26,17 @@ void WayfireLanguage::init(Gtk::Box *container)
         return;
     }
 
-    button.add_css_class("language");
-    button.add_css_class("flat");
-    button.remove_css_class("activated");
-    btn_sig = button.signal_clicked().connect(sigc::mem_fun(*this, &WayfireLanguage::next_layout));
-    button.show();
+    label.add_css_class("language");
+    auto click_gesture = Gtk::GestureClick::create();
+    click_gesture->set_button(1);
+    btn_sig = click_gesture->signal_released().connect(
+        [this] (int count, double x, double y)
+    {
+        next_layout();
+    });
+    label.add_controller(click_gesture);
 
-    container->append(button);
+    container->append(label);
 
     ipc_client->subscribe(this, {"keyboard-modifier-state-changed"});
     ipc_client->send("{\"method\":\"wayfire/get-keyboard-state\"}", [=] (wf::json_t data)
@@ -74,7 +78,7 @@ bool WayfireLanguage::update_label()
         return false;
     }
 
-    button.set_label(available_layouts[current_layout].ID);
+    label.set_label(available_layouts[current_layout].ID);
     return true;
 }
 

--- a/src/panel/widgets/language.hpp
+++ b/src/panel/widgets/language.hpp
@@ -20,9 +20,8 @@ struct Layout
 
 class WayfireLanguage : public WayfireWidget, public IIPCSubscriber
 {
-    Gtk::Button button;
+    Gtk::Label label;
     sigc::connection btn_sig;
-
     std::shared_ptr<IPCClient> ipc_client;
     uint32_t current_layout;
     std::vector<Layout> available_layouts;

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -4,7 +4,7 @@
 #include <glibmm/spawn.h>
 #include <glibmm/keyfile.h>
 #include <gtkmm/icontheme.h>
-#include "gtkmm/gestureclick.h"
+#include <gtkmm/gestureclick.h>
 #include <gdk/gdkcairo.h>
 #include <cassert>
 #include <gtk-utils.hpp>

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -4,6 +4,7 @@
 #include <glibmm/spawn.h>
 #include <glibmm/keyfile.h>
 #include <gtkmm/icontheme.h>
+#include "gtkmm/gestureclick.h"
 #include <gdk/gdkcairo.h>
 #include <cassert>
 #include <gtk-utils.hpp>
@@ -45,19 +46,25 @@ bool WfLauncherButton::initialize(std::string name, std::string icon, std::strin
         return false;
     }
 
-    m_icon.set_halign(Gtk::Align::CENTER);
-    m_icon.set_valign(Gtk::Align::CENTER);
+    m_icon.set_halign(Gtk::Align::FILL);
+    m_icon.set_valign(Gtk::Align::FILL);
+    m_icon.add_css_class("widget-icon");
+    m_icon.add_css_class("launcher");
+    m_icon.set_halign(Gtk::Align::FILL);
+    m_icon.set_valign(Gtk::Align::FILL);
 
-    button.set_child(m_icon);
-    button.add_css_class("widget-icon");
-    button.add_css_class("flat");
-    button.add_css_class("launcher");
-
-    btn_sig = button.signal_clicked().connect([=] () { launch(); });
+    auto click = Gtk::GestureClick::create();
+    click->set_button(1);
+    btn_sig = click->signal_released().connect(
+        [this] (int, double, double)
+    {
+        launch();
+    });
+    m_icon.add_controller(click);
 
     update_icon();
 
-    button.set_tooltip_text(app_info->get_name());
+    m_icon.set_tooltip_text(app_info->get_name());
     return true;
 }
 
@@ -157,8 +164,8 @@ void WayfireLaunchers::init(Gtk::Box *container)
 
     container->append(box);
 
-    box.set_halign(Gtk::Align::CENTER);
-    box.set_valign(Gtk::Align::CENTER);
+    box.set_halign(Gtk::Align::FILL);
+    box.set_valign(Gtk::Align::FILL);
 
     handle_config_reload();
 }
@@ -190,7 +197,7 @@ void WayfireLaunchers::handle_config_reload()
     launchers = get_launchers_from_config();
     for (auto& l : launchers)
     {
-        box.append(l->button);
+        box.append(l->m_icon);
     }
 
     update_layout();

--- a/src/panel/widgets/launchers.hpp
+++ b/src/panel/widgets/launchers.hpp
@@ -11,7 +11,6 @@
 struct WfLauncherButton
 {
     Gtk::Image m_icon;
-    Gtk::Button button;
     sigc::connection btn_sig;
     Glib::RefPtr<Gio::DesktopAppInfo> app_info;
 

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -11,6 +11,7 @@
 #include "menu.hpp"
 #include "gtk-utils.hpp"
 #include "wf-autohide-window.hpp"
+#include "wf-popover.hpp"
 
 const std::string default_icon = "wayfire";
 
@@ -542,7 +543,7 @@ bool WayfireMenu::update_icon()
 
 void WayfireMenu::setup_popover_layout()
 {
-    button->set_popover_child(popover_layout_box);
+    button->set_popup_child(popover_layout_box);
 
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);
     flowbox.set_activate_on_single_click(true);
@@ -913,12 +914,13 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_show_categories.set_callback([=] () { update_popover_layout(); });
     menu_list.set_callback([=] () { update_popover_layout(); });
 
-    button = std::make_unique<WayfireMenuButton>("panel", "menu");
+    button = std::make_unique<WayfireMenuWidget>("panel", "menu");
     fullscreen.add_css_class("menu-fullscreen");
     button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
     button->get_children()[0]->add_css_class("flat");
+    button->open_on(1); /* Open menu on left click */
     signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
 
@@ -941,7 +943,7 @@ void WayfireMenu::init(Gtk::Box *container)
     signals.push_back(button->property_scale_factor().signal_changed().connect(
         [=] () {update_icon(); }));
 
-    button->set_popover_child(popover_layout_box);
+    button->set_popup_child(popover_layout_box);
 
     container->append(box);
     box.append(*button);

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -518,12 +518,6 @@ void WayfireMenu::on_popover_shown()
     on_search_changed();
     set_category("All");
     flowbox.unselect_all();
-
-    if (force_show_popup.value())
-    {
-        Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
-        gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-    }
 }
 
 bool WayfireMenu::update_icon()
@@ -623,36 +617,6 @@ void WayfireMenu::setup_popover_layout()
         return false;
     }, false));
     popover_layout_box.add_controller(typing_gesture);
-    signals.push_back(button->signal_popdown().connect([=] ()
-    {
-        if (!force_show_popup.value())
-        {
-            return;
-        }
-
-        Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
-        WfOption<std::string> panel_layer{"panel/layer"};
-
-        if ((std::string)panel_layer == "overlay")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-        }
-
-        if ((std::string)panel_layer == "top")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_TOP);
-        }
-
-        if ((std::string)panel_layer == "bottom")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
-        }
-
-        if ((std::string)panel_layer == "background")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
-        }
-    }));
 }
 
 void WayfireMenu::update_popover_layout()
@@ -979,7 +943,7 @@ void WayfireMenu::init(Gtk::Box *container)
     update_popover_layout();
     populate_menu_categories();
     populate_menu_items("All");
-
+    app_info_monitor = g_app_info_monitor_get();
     app_info_monitor_changed_handler_id =
         g_signal_connect(app_info_monitor, "changed", G_CALLBACK(app_info_changed), this);
 
@@ -1038,7 +1002,11 @@ void WayfireMenu::select_first_flowbox_item()
 
 WayfireMenu::~WayfireMenu()
 {
-    g_signal_handler_disconnect(app_info_monitor, app_info_monitor_changed_handler_id);
+    if (app_info_monitor)
+    {
+        g_signal_handler_disconnect(app_info_monitor, app_info_monitor_changed_handler_id);
+    }
+
     for (auto signal : signals)
     {
         signal.disconnect();

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -542,13 +542,7 @@ bool WayfireMenu::update_icon()
 
 void WayfireMenu::setup_popover_layout()
 {
-    if (menu_fullscreen)
-    {
-        fullscreen.set_child(popover_layout_box);
-    } else
-    {
-        button->get_popover()->set_child(popover_layout_box);
-    }
+    button->set_popover_child(popover_layout_box);
 
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);
     flowbox.set_activate_on_single_click(true);
@@ -612,7 +606,7 @@ void WayfireMenu::setup_popover_layout()
             return true;
         } else if (keyval == GDK_KEY_Escape)
         {
-            button->get_popover()->hide();
+            button->popdown();
             fullscreen.hide();
         } else
         {
@@ -628,7 +622,7 @@ void WayfireMenu::setup_popover_layout()
         return false;
     }, false));
     popover_layout_box.add_controller(typing_gesture);
-    signals.push_back(button->get_popover()->signal_closed().connect([=] ()
+    signals.push_back(button->signal_popdown().connect([=] ()
     {
         if (!force_show_popup.value())
         {
@@ -836,7 +830,7 @@ WayfireLogoutUI::~WayfireLogoutUI()
 
 void WayfireMenu::on_logout_click()
 {
-    button->get_popover()->hide();
+    button->popdown();
     fullscreen.hide();
     if (!std::string(menu_logout_command).empty())
     {
@@ -919,14 +913,13 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_show_categories.set_callback([=] () { update_popover_layout(); });
     menu_list.set_callback([=] () { update_popover_layout(); });
 
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "menu");
     fullscreen.add_css_class("menu-fullscreen");
-    button->set_child(main_image);
+    button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
-    button->get_popover()->add_css_class("menu-popover");
     button->get_children()[0]->add_css_class("flat");
-    signals.push_back(button->get_popover()->signal_show().connect(
+    signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
 
     /* Prepare fullscreen layer */
@@ -948,20 +941,7 @@ void WayfireMenu::init(Gtk::Box *container)
     signals.push_back(button->property_scale_factor().signal_changed().connect(
         [=] () {update_icon(); }));
 
-    menu_fullscreen.set_callback([=] ()
-    {
-        fullscreen.hide();
-        button->set_active(false);
-        if (menu_fullscreen)
-        {
-            gtk_popover_set_child(button->get_popover()->gobj(), nullptr);
-            fullscreen.set_child(popover_layout_box);
-        } else
-        {
-            gtk_window_set_child(fullscreen.gobj(), nullptr);
-            button->get_popover()->set_child(popover_layout_box);
-        }
-    });
+    button->set_popover_child(popover_layout_box);
 
     container->append(box);
     box.append(*button);
@@ -1026,27 +1006,13 @@ void WayfireMenu::toggle_menu()
 {
     search_contents = "";
     search_entry.set_text("");
-    if (menu_fullscreen)
-    {
-        if (fullscreen.is_visible())
-        {
-            fullscreen.hide();
-        } else
-        {
-            fullscreen.show();
-            on_popover_shown();
-        }
 
-        return;
-    }
-
-    button->set_active(!button->get_active());
+    button->toggle();
 }
 
 void WayfireMenu::hide_menu()
 {
-    button->set_active(false);
-    fullscreen.hide();
+    button->popdown();
 }
 
 void WayfireMenu::set_category(std::string in_category)

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -602,7 +602,6 @@ void WayfireMenu::setup_popover_layout()
         } else if (keyval == GDK_KEY_Escape)
         {
             button->popdown();
-            fullscreen.hide();
         } else
         {
             std::string input = gdk_keyval_name(keyval);
@@ -796,7 +795,6 @@ WayfireLogoutUI::~WayfireLogoutUI()
 void WayfireMenu::on_logout_click()
 {
     button->popdown();
-    fullscreen.hide();
     if (!std::string(menu_logout_command).empty())
     {
         g_spawn_command_line_async(std::string(menu_logout_command).c_str(), NULL);
@@ -879,7 +877,6 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_list.set_callback([=] () { update_popover_layout(); });
 
     button = std::make_unique<WayfireMenuWidget>("panel", "menu");
-    fullscreen.add_css_class("menu-fullscreen");
     button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
@@ -887,17 +884,6 @@ void WayfireMenu::init(Gtk::Box *container)
     button->open_on(1); /* Open menu on left click */
     signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
-
-    /* Prepare fullscreen layer */
-    gtk_layer_init_for_window(fullscreen.gobj());
-    gtk_layer_set_monitor(fullscreen.gobj(), output->monitor->gobj());
-    gtk_layer_set_namespace(fullscreen.gobj(), "panelmenu");
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_TOP, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_LEFT, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, true);
-    gtk_layer_set_layer(fullscreen.gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-    gtk_layer_set_keyboard_mode(fullscreen.gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
 
     if (!update_icon())
     {
@@ -923,6 +909,13 @@ void WayfireMenu::init(Gtk::Box *container)
         toggle_menu();
     }));
     box.add_controller(click_gesture);
+
+    auto menu_fs_changed = [=]
+    {
+        button->set_fullscreen(menu_fullscreen.value());
+    };
+    menu_fullscreen.set_callback(menu_fs_changed);
+    menu_fs_changed();
 
     logout_image.set_icon_size(Gtk::IconSize::LARGE);
     logout_image.set_from_icon_name("system-shutdown");

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -647,7 +647,6 @@ void WayfireMenu::setup_popover_layout()
         } else if (keyval == GDK_KEY_Escape)
         {
             button->popdown();
-            fullscreen.hide();
             return true;
         } else if ((keyval == GDK_KEY_Up) ||
                    (keyval == GDK_KEY_Down) ||
@@ -869,7 +868,6 @@ WayfireLogoutUI::~WayfireLogoutUI()
 void WayfireMenu::on_logout_click()
 {
     button->popdown();
-    fullscreen.hide();
     if (!menu_logout_command.value().empty())
     {
         g_spawn_command_line_async(menu_logout_command.value().c_str(), NULL);
@@ -957,7 +955,6 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_list.set_callback([=] () { update_popover_layout(); });
 
     button = std::make_unique<WayfireMenuWidget>("panel", "menu");
-    fullscreen.add_css_class("menu-fullscreen");
     button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
@@ -965,17 +962,6 @@ void WayfireMenu::init(Gtk::Box *container)
     button->open_on(1); /* Open menu on left click */
     signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
-
-    /* Prepare fullscreen layer */
-    gtk_layer_init_for_window(fullscreen.gobj());
-    gtk_layer_set_monitor(fullscreen.gobj(), output->monitor->gobj());
-    gtk_layer_set_namespace(fullscreen.gobj(), "panelmenu");
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_TOP, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_LEFT, true);
-    gtk_layer_set_anchor(fullscreen.gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, true);
-    gtk_layer_set_layer(fullscreen.gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-    gtk_layer_set_keyboard_mode(fullscreen.gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
 
     if (!update_icon())
     {
@@ -1001,6 +987,13 @@ void WayfireMenu::init(Gtk::Box *container)
         toggle_menu();
     }));
     box.add_controller(click_gesture);
+
+    auto menu_fs_changed = [=]
+    {
+        button->set_fullscreen(menu_fullscreen.value());
+    };
+    menu_fullscreen.set_callback(menu_fs_changed);
+    menu_fs_changed();
 
     logout_image.set_icon_size(Gtk::IconSize::LARGE);
     logout_image.set_from_icon_name("system-shutdown");

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -560,12 +560,6 @@ void WayfireMenu::on_popover_shown()
     on_search_changed();
     set_category("All");
     flowbox.unselect_all();
-
-    if (force_show_popup.value())
-    {
-        Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
-        gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-    }
 }
 
 bool WayfireMenu::update_icon()
@@ -688,36 +682,6 @@ void WayfireMenu::setup_popover_layout()
         }
     }, false));
     popover_layout_box.add_controller(typing_gesture);
-    signals.push_back(button->signal_popdown().connect([=] ()
-    {
-        if (!force_show_popup.value())
-        {
-            return;
-        }
-
-        Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
-        WfOption<std::string> panel_layer{"panel/layer"};
-
-        if (panel_layer.value() == "overlay")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-        }
-
-        if (panel_layer.value() == "top")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_TOP);
-        }
-
-        if (panel_layer.value() == "bottom")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
-        }
-
-        if (panel_layer.value() == "background")
-        {
-            gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
-        }
-    }));
 }
 
 void WayfireMenu::update_popover_layout()
@@ -1057,7 +1021,7 @@ void WayfireMenu::init(Gtk::Box *container)
     update_popover_layout();
     populate_menu_categories();
     populate_menu_items("All");
-
+    app_info_monitor = g_app_info_monitor_get();
     app_info_monitor_changed_handler_id =
         g_signal_connect(app_info_monitor, "changed", G_CALLBACK(app_info_changed), this);
 
@@ -1115,7 +1079,11 @@ void WayfireMenu::select_first_flowbox_item()
 
 WayfireMenu::~WayfireMenu()
 {
-    g_signal_handler_disconnect(app_info_monitor, app_info_monitor_changed_handler_id);
+    if (app_info_monitor)
+    {
+        g_signal_handler_disconnect(app_info_monitor, app_info_monitor_changed_handler_id);
+    }
+
     for (auto signal : signals)
     {
         signal.disconnect();

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -958,8 +958,6 @@ void WayfireMenu::init(Gtk::Box *container)
     button->append(main_image);
     button->set_keyboard_interactive(true);
     button->add_css_class("menu-button");
-    button->add_css_class("flat");
-    button->get_children()[0]->add_css_class("flat");
     button->open_on(1); /* Open menu on left click */
     signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -24,6 +24,8 @@ void WfMenuLayout::allocate_vfunc(const Gtk::Widget& widget, int width, int heig
         return;
     }
 
+    bool is_top = panel_position.value() == WF_WINDOW_POSITION_TOP;
+
     Gtk::Widget::Measurements entry_measurements, logout_measurements, separator_measurements;
     entry_measurements     = menu->search_entry.measure(Gtk::Orientation::VERTICAL, width);
     logout_measurements    = menu->box_bottom.measure(Gtk::Orientation::VERTICAL, width);
@@ -39,7 +41,9 @@ void WfMenuLayout::allocate_vfunc(const Gtk::Widget& widget, int width, int heig
     }
 
     search_alloc.set_x(0);
-    search_alloc.set_y(0);
+    search_alloc.set_y(is_top ? 0 : height -
+        (logout_measurements.sizes.minimum + separator_measurements.sizes.natural +
+            entry_measurements.sizes.minimum));
     search_alloc.set_height(entry_measurements.sizes.minimum);
     search_alloc.set_width(width);
     menu->search_entry.size_allocate(search_alloc, -1);
@@ -60,13 +64,13 @@ void WfMenuLayout::allocate_vfunc(const Gtk::Widget& widget, int width, int heig
     if (show_categories.value())
     {
         category_alloc.set_x(0);
-        category_alloc.set_y(entry_measurements.sizes.minimum);
+        category_alloc.set_y(is_top ? entry_measurements.sizes.minimum : 0);
         category_alloc.set_width(category_width);
         category_alloc.set_height(remaining_height);
         menu->category_scrolled_window.size_allocate(category_alloc, -1);
 
         flow_alloc.set_x(category_width);
-        flow_alloc.set_y(entry_measurements.sizes.minimum);
+        flow_alloc.set_y(is_top ? entry_measurements.sizes.minimum : 0);
         flow_alloc.set_width(width - category_width);
         flow_alloc.set_height(remaining_height);
         menu->app_scrolled_window.size_allocate(flow_alloc, -1);
@@ -74,13 +78,13 @@ void WfMenuLayout::allocate_vfunc(const Gtk::Widget& widget, int width, int heig
     {
         /* Even if we're not having it, allocate some space */
         category_alloc.set_x(0);
-        category_alloc.set_y(entry_measurements.sizes.minimum);
+        category_alloc.set_y(is_top ? entry_measurements.sizes.minimum : 0);
         category_alloc.set_width(width);
         category_alloc.set_height(remaining_height);
         menu->category_scrolled_window.size_allocate(category_alloc, -1);
 
         flow_alloc.set_x(0);
-        flow_alloc.set_y(entry_measurements.sizes.minimum);
+        flow_alloc.set_y(is_top ? entry_measurements.sizes.minimum : 0);
         flow_alloc.set_width(width);
         flow_alloc.set_height(remaining_height);
         menu->app_scrolled_window.size_allocate(flow_alloc, -1);

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -584,13 +584,7 @@ bool WayfireMenu::update_icon()
 
 void WayfireMenu::setup_popover_layout()
 {
-    if (menu_fullscreen)
-    {
-        fullscreen.set_child(popover_layout_box);
-    } else
-    {
-        button->get_popover()->set_child(popover_layout_box);
-    }
+    button->set_popover_child(popover_layout_box);
 
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);
     flowbox.set_activate_on_single_click(true);
@@ -657,7 +651,7 @@ void WayfireMenu::setup_popover_layout()
             return true;
         } else if (keyval == GDK_KEY_Escape)
         {
-            button->get_popover()->hide();
+            button->popdown();
             fullscreen.hide();
             return true;
         } else if ((keyval == GDK_KEY_Up) ||
@@ -693,7 +687,7 @@ void WayfireMenu::setup_popover_layout()
         }
     }, false));
     popover_layout_box.add_controller(typing_gesture);
-    signals.push_back(button->get_popover()->signal_closed().connect([=] ()
+    signals.push_back(button->signal_popdown().connect([=] ()
     {
         if (!force_show_popup.value())
         {
@@ -909,7 +903,7 @@ WayfireLogoutUI::~WayfireLogoutUI()
 
 void WayfireMenu::on_logout_click()
 {
-    button->get_popover()->hide();
+    button->popdown();
     fullscreen.hide();
     if (!menu_logout_command.value().empty())
     {
@@ -997,14 +991,13 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_show_categories.set_callback([=] () { update_popover_layout(); });
     menu_list.set_callback([=] () { update_popover_layout(); });
 
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "menu");
     fullscreen.add_css_class("menu-fullscreen");
-    button->set_child(main_image);
+    button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
-    button->get_popover()->add_css_class("menu-popover");
     button->get_children()[0]->add_css_class("flat");
-    signals.push_back(button->get_popover()->signal_show().connect(
+    signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
 
     /* Prepare fullscreen layer */
@@ -1026,20 +1019,7 @@ void WayfireMenu::init(Gtk::Box *container)
     signals.push_back(button->property_scale_factor().signal_changed().connect(
         [=] () {update_icon(); }));
 
-    menu_fullscreen.set_callback([=] ()
-    {
-        fullscreen.hide();
-        button->set_active(false);
-        if (menu_fullscreen)
-        {
-            gtk_popover_set_child(button->get_popover()->gobj(), nullptr);
-            fullscreen.set_child(popover_layout_box);
-        } else
-        {
-            gtk_window_set_child(fullscreen.gobj(), nullptr);
-            button->get_popover()->set_child(popover_layout_box);
-        }
-    });
+    button->set_popover_child(popover_layout_box);
 
     container->append(box);
     box.append(*button);
@@ -1103,27 +1083,13 @@ void WayfireMenu::update_content_width()
 void WayfireMenu::toggle_menu()
 {
     search_entry.set_text("");
-    if (menu_fullscreen)
-    {
-        if (fullscreen.is_visible())
-        {
-            fullscreen.hide();
-        } else
-        {
-            fullscreen.show();
-            on_popover_shown();
-        }
 
-        return;
-    }
-
-    button->set_active(!button->get_active());
+    button->toggle();
 }
 
 void WayfireMenu::hide_menu()
 {
-    button->set_active(false);
-    fullscreen.hide();
+    button->popdown();
 }
 
 void WayfireMenu::set_category(std::string in_category)

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -114,12 +114,15 @@ void WfMenuLayout::measure_vfunc(const Gtk::Widget& widget, Gtk::Orientation ori
             return;
         }
 
-        Gtk::Widget::Measurements entry_measurements, logout_measurements;
-        entry_measurements  = menu->search_entry.measure(Gtk::Orientation::VERTICAL, for_size);
-        logout_measurements = menu->box_bottom.measure(Gtk::Orientation::VERTICAL, for_size);
+        Gtk::Widget::Measurements entry_measurements, logout_measurements, separator_measurements;
+        entry_measurements     = menu->search_entry.measure(Gtk::Orientation::VERTICAL, for_size);
+        logout_measurements    = menu->box_bottom.measure(Gtk::Orientation::VERTICAL, for_size);
+        separator_measurements = menu->separator.measure(Gtk::Orientation::VERTICAL, for_size);
 
-        minimum = entry_measurements.sizes.minimum + logout_measurements.sizes.minimum + content_height;
-        natural = entry_measurements.sizes.minimum + logout_measurements.sizes.minimum + content_height;
+        minimum = separator_measurements.sizes.natural + entry_measurements.sizes.minimum +
+            logout_measurements.sizes.minimum + content_height;
+        natural = separator_measurements.sizes.natural + entry_measurements.sizes.minimum +
+            logout_measurements.sizes.minimum + content_height;
     }
 }
 
@@ -704,6 +707,7 @@ void WayfireMenu::setup_popover_layout()
     popover_layout_box.append(app_scrolled_window);
     popover_layout_box.append(category_scrolled_window);
     popover_layout_box.append(search_entry);
+    popover_layout_box.append(separator);
     popover_layout_box.append(box_bottom);
 
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -494,7 +494,6 @@ void WayfireMenu::on_search_changed()
             /* Text has been unset, show categories again */
             populate_menu_items(category);
             category_scrolled_window.show();
-            app_scrolled_window.set_min_content_width(int(menu_min_content_width));
         } else
         {
             /* User is filtering, hide categories, ignore chosen category */
@@ -589,8 +588,8 @@ void WayfireMenu::setup_popover_layout()
     flowbox.set_sort_func(sigc::mem_fun(*this, &WayfireMenu::on_sort));
     flowbox.set_filter_func(sigc::mem_fun(*this, &WayfireMenu::on_filter));
     flowbox.add_css_class("app-list");
-    flowbox.set_size_request(int(menu_min_content_width), int(menu_min_content_height));
     flowbox.set_vexpand(true);
+    flowbox.set_hexpand(true);
 
     flowbox_container.append(flowbox);
 
@@ -599,8 +598,6 @@ void WayfireMenu::setup_popover_layout()
     scroll_pair.set_homogeneous(false);
     scroll_pair.set_vexpand(true);
 
-    app_scrolled_window.set_min_content_width(int(menu_min_content_width));
-    app_scrolled_window.set_min_content_height(int(menu_min_content_height));
     app_scrolled_window.set_child(flowbox_container);
     app_scrolled_window.add_css_class("app-list-scroll");
     app_scrolled_window.set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::AUTOMATIC);
@@ -609,8 +606,6 @@ void WayfireMenu::setup_popover_layout()
     category_box.add_css_class("category-list");
     category_box.set_orientation(Gtk::Orientation::VERTICAL);
 
-    category_scrolled_window.set_min_content_width(int(menu_min_category_width));
-    category_scrolled_window.set_min_content_height(int(menu_min_content_height));
     category_scrolled_window.set_child(category_box);
     category_scrolled_window.add_css_class("categtory-list-scroll");
     category_scrolled_window.set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::AUTOMATIC);
@@ -948,9 +943,9 @@ void WayfireMenu::init(Gtk::Box *container)
         flowbox.set_column_spacing(flowbox_spacing.value());
         flowbox.set_column_spacing(flowbox_spacing.value());
     });
-    menu_min_category_width.set_callback([=] () { update_category_width(); });
-    menu_min_content_height.set_callback([=] () { update_content_height(); });
-    menu_min_content_width.set_callback([=] () { update_content_width(); });
+    menu_min_category_width.set_callback([=] () { update_size(); });
+    menu_min_content_height.set_callback([=] () { update_size(); });
+    menu_min_content_width.set_callback([=] () { update_size(); });
     panel_position.set_callback([=] () { update_popover_layout(); });
     menu_show_categories.set_callback([=] () { update_popover_layout(); });
     menu_list.set_callback([=] () { update_popover_layout(); });
@@ -1021,22 +1016,31 @@ void WayfireMenu::init(Gtk::Box *container)
     box.show();
     main_image.show();
     button->show();
+
+    signals.push_back(button->get_scroll().signal_map().connect([=] ()
+    {
+        update_size();
+    }));
 }
 
-void WayfireMenu::update_category_width()
+void WayfireMenu::update_size()
 {
-    category_scrolled_window.set_min_content_width(int(menu_min_category_width));
-}
+    int width  = button->get_scroll().get_width();
+    int height = button->get_scroll().get_height();
+    if ((width <= 0) || (height <= 0))
+    {
+        /* Not yet allocated, do it next tick */
+        popover_layout_box.set_size_request(menu_min_content_width.value() + menu_min_category_width,
+            menu_min_content_height);
 
-void WayfireMenu::update_content_height()
-{
-    category_scrolled_window.set_min_content_height(int(menu_min_content_height));
-    app_scrolled_window.set_min_content_height(int(menu_min_content_height));
-}
+        Glib::signal_idle().connect_once([=] ()
+        {
+            update_size();
+        });
+        return;
+    }
 
-void WayfireMenu::update_content_width()
-{
-    app_scrolled_window.set_min_content_width(int(menu_min_content_width));
+    popover_layout_box.set_size_request(width, height);
 }
 
 void WayfireMenu::toggle_menu()

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -1030,8 +1030,14 @@ void WayfireMenu::update_size()
     if ((width <= 0) || (height <= 0))
     {
         /* Not yet allocated, do it next tick */
-        popover_layout_box.set_size_request(menu_min_content_width.value() + menu_min_category_width,
-            menu_min_content_height);
+        width  = menu_min_content_width;
+        height = menu_min_content_height;
+        if (menu_show_categories.value())
+        {
+            width += menu_min_category_width;
+        }
+
+        popover_layout_box.set_size_request(width, height);
 
         Glib::signal_idle().connect_once([=] ()
         {
@@ -1040,6 +1046,7 @@ void WayfireMenu::update_size()
         return;
     }
 
+    /* We know the size of the outside of the scrollbox, use it */
     popover_layout_box.set_size_request(width, height);
 }
 

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -560,6 +560,7 @@ void WayfireMenu::on_popover_shown()
     on_search_changed();
     set_category("All");
     flowbox.unselect_all();
+    search_entry.grab_focus();
 }
 
 bool WayfireMenu::update_icon()

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -6,7 +6,6 @@
 #include <glibmm/spawn.h>
 #include <iostream>
 #include <gtk4-layer-shell.h>
-#include <gtk/gtk.h>
 
 #include "menu.hpp"
 #include "gtk-utils.hpp"
@@ -14,6 +13,127 @@
 #include "wf-popover.hpp"
 
 const std::string default_icon = "wayfire";
+
+WfMenuLayout::WfMenuLayout(WayfireMenu *menu) : menu(menu)
+{}
+
+void WfMenuLayout::allocate_vfunc(const Gtk::Widget& widget, int width, int height, int baseline)
+{
+    if (menu == nullptr)
+    {
+        return;
+    }
+
+    Gtk::Widget::Measurements entry_measurements, logout_measurements, separator_measurements;
+    entry_measurements     = menu->search_entry.measure(Gtk::Orientation::VERTICAL, width);
+    logout_measurements    = menu->box_bottom.measure(Gtk::Orientation::VERTICAL, width);
+    separator_measurements = menu->separator.measure(Gtk::Orientation::VERTICAL, width);
+
+    int remaining_height = height -
+        (entry_measurements.sizes.minimum +
+            logout_measurements.sizes.minimum +
+            separator_measurements.sizes.natural);
+    if (remaining_height <= 0)
+    {
+        return;
+    }
+
+    search_alloc.set_x(0);
+    search_alloc.set_y(0);
+    search_alloc.set_height(entry_measurements.sizes.minimum);
+    search_alloc.set_width(width);
+    menu->search_entry.size_allocate(search_alloc, -1);
+
+    logout_alloc.set_x(0);
+    logout_alloc.set_y(height - logout_measurements.sizes.minimum);
+    logout_alloc.set_width(width);
+    logout_alloc.set_height(logout_measurements.sizes.minimum);
+    menu->box_bottom.size_allocate(logout_alloc, -1);
+
+    separator_alloc.set_x(0);
+    separator_alloc.set_y(height -
+        (logout_measurements.sizes.minimum + separator_measurements.sizes.natural));
+    separator_alloc.set_width(width);
+    separator_alloc.set_height(separator_measurements.sizes.natural);
+    menu->separator.size_allocate(separator_alloc, -1);
+
+    if (show_categories.value())
+    {
+        category_alloc.set_x(0);
+        category_alloc.set_y(entry_measurements.sizes.minimum);
+        category_alloc.set_width(category_width);
+        category_alloc.set_height(remaining_height);
+        menu->category_scrolled_window.size_allocate(category_alloc, -1);
+
+        flow_alloc.set_x(category_width);
+        flow_alloc.set_y(entry_measurements.sizes.minimum);
+        flow_alloc.set_width(width - category_width);
+        flow_alloc.set_height(remaining_height);
+        menu->app_scrolled_window.size_allocate(flow_alloc, -1);
+    } else
+    {
+        /* Even if we're not having it, allocate some space */
+        category_alloc.set_x(0);
+        category_alloc.set_y(entry_measurements.sizes.minimum);
+        category_alloc.set_width(width);
+        category_alloc.set_height(remaining_height);
+        menu->category_scrolled_window.size_allocate(category_alloc, -1);
+
+        flow_alloc.set_x(0);
+        flow_alloc.set_y(entry_measurements.sizes.minimum);
+        flow_alloc.set_width(width);
+        flow_alloc.set_height(remaining_height);
+        menu->app_scrolled_window.size_allocate(flow_alloc, -1);
+    }
+}
+
+void WfMenuLayout::measure_vfunc(const Gtk::Widget& widget, Gtk::Orientation orientation,
+    int for_size, int& minimum, int& natural, int& minimum_baseline,
+    int& natural_baseline) const
+{
+    minimum_baseline = -1;
+    natural_baseline = -1;
+    // What is our preferred width?
+    if (orientation == Gtk::Orientation::HORIZONTAL)
+    {
+        if (limit_width > 0)
+        {
+            minimum = limit_width;
+            natural = limit_width;
+            return;
+        }
+
+        minimum = category_width + content_width;
+        natural = category_width + content_width;
+    } else
+    {
+        if (limit_height > 0)
+        {
+            minimum = limit_height;
+            natural = limit_height;
+            return;
+        }
+
+        Gtk::Widget::Measurements entry_measurements, logout_measurements;
+        entry_measurements  = menu->search_entry.measure(Gtk::Orientation::VERTICAL, for_size);
+        logout_measurements = menu->box_bottom.measure(Gtk::Orientation::VERTICAL, for_size);
+
+        minimum = entry_measurements.sizes.minimum + logout_measurements.sizes.minimum + content_height;
+        natural = entry_measurements.sizes.minimum + logout_measurements.sizes.minimum + content_height;
+    }
+}
+
+void WfMenuLayout::set_limit(int w, int h)
+{
+    if ((w == limit_width) && (h == limit_height))
+    {
+        return;
+    }
+
+    limit_width  = w;
+    limit_height = h;
+    menu->popover_layout_box.queue_resize();
+}
 
 WfMenuCategory::WfMenuCategory(std::string _name, std::string _icon_name) :
     name(_name), icon_name(_icon_name)
@@ -581,6 +701,11 @@ void WayfireMenu::setup_popover_layout()
 {
     button->set_popup_child(popover_layout_box);
 
+    popover_layout_box.append(app_scrolled_window);
+    popover_layout_box.append(category_scrolled_window);
+    popover_layout_box.append(search_entry);
+    popover_layout_box.append(box_bottom);
+
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);
     flowbox.set_activate_on_single_click(true);
     flowbox.set_valign(Gtk::Align::START);
@@ -592,16 +717,9 @@ void WayfireMenu::setup_popover_layout()
     flowbox.set_hexpand(true);
 
     flowbox_container.append(flowbox);
-
-    scroll_pair.append(category_scrolled_window);
-    scroll_pair.append(app_scrolled_window);
-    scroll_pair.set_homogeneous(false);
-    scroll_pair.set_vexpand(true);
-
     app_scrolled_window.set_child(flowbox_container);
     app_scrolled_window.add_css_class("app-list-scroll");
     app_scrolled_window.set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::AUTOMATIC);
-    app_scrolled_window.set_vexpand(true);
 
     category_box.add_css_class("category-list");
     category_box.set_orientation(Gtk::Orientation::VERTICAL);
@@ -677,31 +795,19 @@ void WayfireMenu::setup_popover_layout()
         }
     }, false));
     popover_layout_box.add_controller(typing_gesture);
+
+    layout = std::make_shared<WfMenuLayout>(this);
+    popover_layout_box.set_layout_manager(layout);
 }
 
 void WayfireMenu::update_popover_layout()
 {
-    /* Layout was already initialized, make sure to remove widgets before
-     * adding them again */
-    auto children = popover_layout_box.get_children();
-    if (std::count(children.begin(), children.end(), &search_entry))
+    if (!menu_show_categories)
     {
-        popover_layout_box.remove(search_entry);
-    }
-
-    if (std::count(children.begin(), children.end(), &scroll_pair))
+        category_scrolled_window.hide();
+    } else
     {
-        popover_layout_box.remove(scroll_pair);
-    }
-
-    if (std::count(children.begin(), children.end(), &separator))
-    {
-        popover_layout_box.remove(separator);
-    }
-
-    if (std::count(children.begin(), children.end(), &box_bottom))
-    {
-        popover_layout_box.remove(box_bottom);
+        category_scrolled_window.show();
     }
 
     if (menu_list)
@@ -710,25 +816,6 @@ void WayfireMenu::update_popover_layout()
     } else
     {
         flowbox.set_max_children_per_line(-1);
-    }
-
-    if ((std::string)panel_position == WF_WINDOW_POSITION_TOP)
-    {
-        popover_layout_box.append(search_entry);
-        popover_layout_box.append(scroll_pair);
-        popover_layout_box.append(separator);
-        popover_layout_box.append(box_bottom);
-    } else
-    {
-        popover_layout_box.append(scroll_pair);
-        popover_layout_box.append(search_entry);
-        popover_layout_box.append(separator);
-        popover_layout_box.append(box_bottom);
-    }
-
-    if (!menu_show_categories)
-    {
-        category_scrolled_window.hide();
     }
 }
 
@@ -1037,7 +1124,7 @@ void WayfireMenu::update_size()
             width += menu_min_category_width;
         }
 
-        popover_layout_box.set_size_request(width, height);
+        layout->set_limit(width, height);
 
         Glib::signal_idle().connect_once([=] ()
         {
@@ -1047,7 +1134,7 @@ void WayfireMenu::update_size()
     }
 
     /* We know the size of the outside of the scrollbox, use it */
-    popover_layout_box.set_size_request(width, height);
+    layout->set_limit(width, height);
 }
 
 void WayfireMenu::toggle_menu()

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -956,6 +956,7 @@ void WayfireMenu::init(Gtk::Box *container)
 
     button = std::make_unique<WayfireMenuWidget>("panel", "menu");
     button->append(main_image);
+    button->set_keyboard_interactive(true);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
     button->get_children()[0]->add_css_class("flat");

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -11,6 +11,7 @@
 #include "menu.hpp"
 #include "gtk-utils.hpp"
 #include "wf-autohide-window.hpp"
+#include "wf-popover.hpp"
 
 const std::string default_icon = "wayfire";
 
@@ -584,7 +585,7 @@ bool WayfireMenu::update_icon()
 
 void WayfireMenu::setup_popover_layout()
 {
-    button->set_popover_child(popover_layout_box);
+    button->set_popup_child(popover_layout_box);
 
     flowbox.set_selection_mode(Gtk::SelectionMode::SINGLE);
     flowbox.set_activate_on_single_click(true);
@@ -991,12 +992,13 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_show_categories.set_callback([=] () { update_popover_layout(); });
     menu_list.set_callback([=] () { update_popover_layout(); });
 
-    button = std::make_unique<WayfireMenuButton>("panel", "menu");
+    button = std::make_unique<WayfireMenuWidget>("panel", "menu");
     fullscreen.add_css_class("menu-fullscreen");
     button->append(main_image);
     button->add_css_class("menu-button");
     button->add_css_class("flat");
     button->get_children()[0]->add_css_class("flat");
+    button->open_on(1); /* Open menu on left click */
     signals.push_back(button->signal_popup().connect(
         sigc::mem_fun(*this, &WayfireMenu::on_popover_shown)));
 
@@ -1019,7 +1021,7 @@ void WayfireMenu::init(Gtk::Box *container)
     signals.push_back(button->property_scale_factor().signal_changed().connect(
         [=] () {update_icon(); }));
 
-    button->set_popover_child(popover_layout_box);
+    button->set_popup_child(popover_layout_box);
 
     container->append(box);
     box.append(*button);

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -141,7 +141,7 @@ class WayfireMenu : public WayfireWidget
     std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 
-    GAppInfoMonitor *app_info_monitor = g_app_info_monitor_get();
+    GAppInfoMonitor *app_info_monitor = nullptr;
     guint app_info_monitor_changed_handler_id;
 
     void load_menu_item(AppInfo app_info);
@@ -177,7 +177,6 @@ class WayfireMenu : public WayfireWidget
     WfOption<bool> fuzzy_search_enabled{"panel/menu_fuzzy_search"};
     WfOption<std::string> panel_position{"panel/position"};
     WfOption<std::string> menu_icon{"panel/menu_icon"};
-    WfOption<bool> force_show_popup{"panel/menu_force_show_popup"};
     WfOption<int> menu_min_category_width{"panel/menu_min_category_width"};
     WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
     WfOption<bool> menu_show_categories{"panel/menu_show_categories"};

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -137,7 +137,6 @@ class WayfireMenu : public WayfireWidget
     Gtk::Button logout_button;
     Gtk::Image logout_image;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
-    Gtk::Window fullscreen;
     std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -138,7 +138,7 @@ class WayfireMenu : public WayfireWidget
     Gtk::Image logout_image;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
     Gtk::Window fullscreen;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 
     GAppInfoMonitor *app_info_monitor = g_app_info_monitor_get();

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -138,7 +138,7 @@ class WayfireMenu : public WayfireWidget
     std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 
-    GAppInfoMonitor *app_info_monitor = g_app_info_monitor_get();
+    GAppInfoMonitor *app_info_monitor = nullptr;
     guint app_info_monitor_changed_handler_id;
 
     void load_menu_item(AppInfo app_info);
@@ -175,7 +175,6 @@ class WayfireMenu : public WayfireWidget
     WfOption<std::string> panel_position{"panel/position"};
     WfOption<std::string> menu_icon{"panel/menu_icon"};
     WfOption<int> flowbox_spacing{"panel/menu_item_spacing"};
-    WfOption<bool> force_show_popup{"panel/menu_force_show_popup"};
     WfOption<int> menu_min_category_width{"panel/menu_min_category_width"};
     WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
     WfOption<bool> menu_show_categories{"panel/menu_show_categories"};

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -135,7 +135,7 @@ class WayfireMenu : public WayfireWidget
     Gtk::Image logout_image;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
     Gtk::Window fullscreen;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 
     GAppInfoMonitor *app_info_monitor = g_app_info_monitor_get();

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -180,9 +180,7 @@ class WayfireMenu : public WayfireWidget
     WfOption<bool> menu_fullscreen{"panel/menu_fullscreen"};
     void setup_popover_layout();
     void update_popover_layout();
-    void update_category_width();
-    void update_content_height();
-    void update_content_width();
+    void update_size();
     void create_logout_ui();
     void on_logout_click();
     void key_press_search();

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -5,13 +5,34 @@
 #include <sigc++/connection.h>
 #include <set>
 
-#include "../widget.hpp"
-#include "gtkmm/enums.h"
-#include "gtkmm/orientable.h"
+#include "widget.hpp"
 #include "wf-popover.hpp"
 
 class WayfireMenu;
 using AppInfo = Glib::RefPtr<Gio::DesktopAppInfo>;
+
+class WfMenuLayout : public Gtk::LayoutManager
+{
+  protected:
+    Gtk::Allocation search_alloc, logout_alloc, category_alloc, flow_alloc, separator_alloc;
+
+    void allocate_vfunc(const Gtk::Widget& widget, int width, int height, int baseline) override;
+    void measure_vfunc(const Gtk::Widget& widget, Gtk::Orientation orientation, int for_size, int& minimum,
+        int& natural, int& minimum_baseline, int& natural_baseline) const override;
+    WayfireMenu *menu;
+    int limit_width = 0, limit_height = 0;
+
+    WfOption<bool> show_categories{"panel/menu_show_categories"};
+    WfOption<int> category_width{"panel/menu_min_category_width"};
+    WfOption<int> content_width{"panel/menu_min_content_width"};
+    WfOption<int> content_height{"panel/menu_min_content_height"};
+
+  public:
+    WfMenuLayout(WayfireMenu *menu);
+
+    void set_limit(int x, int y);
+};
+
 
 class WfMenuCategory
 {
@@ -122,9 +143,9 @@ class WayfireMenu : public WayfireWidget
 {
     WayfireOutput *output;
 
+  public:
     Gtk::Box flowbox_container;
-    Gtk::Box box, box_bottom, scroll_pair;
-    Gtk::Box bottom_pad;
+    Gtk::Box box, box_bottom;
     Gtk::Box popover_layout_box;
     Gtk::Box category_box;
     Gtk::Separator separator;
@@ -134,6 +155,9 @@ class WayfireMenu : public WayfireWidget
     Gtk::Button logout_button;
     Gtk::Image logout_image;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
+
+  private:
+    std::shared_ptr<WfMenuLayout> layout;
     std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -134,7 +134,6 @@ class WayfireMenu : public WayfireWidget
     Gtk::Button logout_button;
     Gtk::Image logout_image;
     Gtk::ScrolledWindow app_scrolled_window, category_scrolled_window;
-    Gtk::Window fullscreen;
     std::unique_ptr<WayfireMenuWidget> button;
     std::unique_ptr<WayfireLogoutUI> logout_ui;
 

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -26,6 +26,7 @@ class WfMenuLayout : public Gtk::LayoutManager
     WfOption<int> category_width{"panel/menu_min_category_width"};
     WfOption<int> content_width{"panel/menu_min_content_width"};
     WfOption<int> content_height{"panel/menu_min_content_height"};
+    WfOption<std::string> panel_position{"panel/position"};
 
   public:
     WfMenuLayout(WayfireMenu *menu);

--- a/src/panel/widgets/mixer/mixer-control.cpp
+++ b/src/panel/widgets/mixer/mixer-control.cpp
@@ -73,7 +73,7 @@ void MixerControl::init()
     {
         // if the menu was popped up because of an external change
         // and is now changed manually, don’t hide
-        parent->cancel_popover_timeout();
+        parent->button->popup();
         ignore = true;
         // disregarding the return value prevents cases where ignore is read at an ncorrect time,
         // with the only problem of having one update ignored if something goes very wrong
@@ -83,7 +83,7 @@ void MixerControl::init()
     scale.set_user_changed_callback(
         [this, id] ()
     {
-        parent->cancel_popover_timeout(); // see above
+        parent->button->popup();
         ignore = true;
         WpCommon::get().set_volume(id, scale.get_target_value());
     });

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -73,7 +73,7 @@ void WayfireMixer::reload_config()
         // unschedule hiding
         cancel_popover_timeout();
 
-        if ((button->get_popover_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
+        if ((button->get_popup_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
         {
             button->popdown();
             return;
@@ -84,9 +84,9 @@ void WayfireMixer::reload_config()
             button->popup();
         }
 
-        if (button->get_popover_child() != (Gtk::Widget*)&master_box)
+        if (button->get_popup_child() != (Gtk::Widget*)&master_box)
         {
-            button->set_popover_child(master_box);
+            button->set_popup_child(master_box);
             popover_timeout.disconnect();
         }
     };
@@ -100,7 +100,7 @@ void WayfireMixer::reload_config()
             return; // no quick_target means we have nothing to show
         }
 
-        if ((button->get_popover_child() == quick_target.get()) && button->is_popup_visible())
+        if ((button->get_popup_child() == quick_target.get()) && button->is_popup_visible())
         {
             button->popdown();
             return;
@@ -111,9 +111,9 @@ void WayfireMixer::reload_config()
             button->popup();
         }
 
-        if (button->get_popover_child() != quick_target.get())
+        if (button->get_popup_child() != quick_target.get())
         {
-            button->set_popover_child(*quick_target);
+            button->set_popup_child(*quick_target);
             popover_timeout.disconnect();
         }
     };
@@ -137,9 +137,9 @@ void WayfireMixer::reload_config()
         {
             // unschedule hiding
             cancel_popover_timeout();
-            if (button->get_popover_child() != (Gtk::Widget*)&master_box)
+            if (button->get_popup_child() != (Gtk::Widget*)&master_box)
             {
-                button->set_popover_child(master_box);
+                button->set_popup_child(master_box);
                 // popdown so that when the click is processed, the popover is down, and thus pops up
                 // not the prettiest result, as it visibly closes instead of just replacing, but i’m not sure
                 // how to make it better
@@ -160,9 +160,9 @@ void WayfireMixer::reload_config()
                 return;
             }
 
-            if (button->get_popover_child() != quick_target.get())
+            if (button->get_popup_child() != quick_target.get())
             {
-                button->set_popover_child(*quick_target);
+                button->set_popup_child(*quick_target);
                 // same as above
                 button->popdown();
             }
@@ -219,17 +219,18 @@ void WayfireMixer::init(Gtk::Box *container)
 {
     // sets up the "widget part"
 
-    button = std::make_unique<WayfireMenuButton>("panel", "mixer");
+    button = std::make_unique<WayfireMenuWidget>("panel", "mixer");
     button->add_css_class("widget-icon");
     button->append(main_image);
     button->show();
+    button->open_on(1);
     sinks_box.add_css_class("outputs");
     sources_box.add_css_class("inputs");
     streams_box.add_css_class("streams");
     out_in_wall.add_css_class("out-in");
     in_streams_wall.add_css_class("in-streams");
 
-    button->set_popover_child(master_box);
+    button->set_popup_child(master_box);
 
     // scroll to change volume of the object targetted by the quick_target widget
     auto scroll_gesture = Gtk::EventControllerScroll::create();

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -8,25 +8,6 @@
 
 #define ICON(volume) icon_from_range(volume_icons, volume)
 
-bool WayfireMixer::on_popover_timeout(int timer)
-{
-    popover_timeout.disconnect();
-    button->popdown();
-    return false;
-}
-
-void WayfireMixer::check_set_popover_timeout()
-{
-    popover_timeout.disconnect();
-
-    popover_timeout = Glib::signal_timeout().connect(sigc::bind(sigc::mem_fun(*this,
-        &WayfireMixer::on_popover_timeout), 0), timeout * 1000);
-}
-
-void WayfireMixer::cancel_popover_timeout()
-{
-    popover_timeout.disconnect();
-}
 
 void WayfireMixer::reload_config()
 {
@@ -67,34 +48,17 @@ void WayfireMixer::reload_config()
     }
 
     // "actions" that can be bound to different clicks
-
     auto show_mixer_action = [&] (int c, double x, double y)
     {
-        // unschedule hiding
-        cancel_popover_timeout();
-
-        if ((button->get_popup_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
-        {
-            button->popdown();
-            return;
-        }
-
-        if (!button->is_popup_visible())
-        {
-            button->popup();
-        }
-
         if (button->get_popup_child() != (Gtk::Widget*)&master_box)
         {
             button->set_popup_child(master_box);
-            popover_timeout.disconnect();
         }
     };
 
     auto show_quick_target_action = [&] (int c, double x, double y)
     {
         // unschedule hiding
-        cancel_popover_timeout();
         if (!quick_target)
         {
             return; // no quick_target means we have nothing to show
@@ -114,7 +78,6 @@ void WayfireMixer::reload_config()
         if (button->get_popup_child() != quick_target.get())
         {
             button->set_popup_child(*quick_target);
-            popover_timeout.disconnect();
         }
     };
 
@@ -128,71 +91,52 @@ void WayfireMixer::reload_config()
         quick_target->button.set_active(!quick_target->button.get_active());
     };
 
-    // the left click case is a bit special, since it’s supposed to show the popover.
-    // (this is also why the mute action is not available for the left click)
     if (str_wp_left_click_action.value() == "show_mixer")
     {
-        left_conn = left_click_gesture->signal_pressed().connect(
-            [&] (int c, double x, double y)
-        {
-            // unschedule hiding
-            cancel_popover_timeout();
-            if (button->get_popup_child() != (Gtk::Widget*)&master_box)
-            {
-                button->set_popup_child(master_box);
-            }
-        });
+        button->open_on(1);
+        left_conn = left_click_gesture->signal_released().connect(show_mixer_action);
     }
 
     if (str_wp_left_click_action.value() == "show_quick_target")
     {
-        left_conn = left_click_gesture->signal_pressed().connect(
-            [&] (int c, double x, double y)
-        {
-            // unschedule hiding
-            cancel_popover_timeout();
-            if (!quick_target)
-            {
-                return;
-            }
-
-            if (button->get_popup_child() != quick_target.get())
-            {
-                button->set_popup_child(*quick_target);
-            }
-        });
+        left_conn = left_click_gesture->signal_released().connect(show_quick_target_action);
     }
 
-    // more simple matching
+    if (str_wp_left_click_action.value() == "mute_quick_target")
+    {
+        left_conn = left_click_gesture->signal_released().connect(mute_action);
+    }
 
     if (str_wp_middle_click_action.value() == "show_mixer")
     {
-        middle_conn = middle_click_gesture->signal_pressed().connect(show_mixer_action);
+        button->open_on(3);
+        middle_conn = middle_click_gesture->signal_released().connect(show_mixer_action);
     }
 
     if (str_wp_middle_click_action.value() == "show_quick_target")
     {
-        middle_conn = middle_click_gesture->signal_pressed().connect(show_quick_target_action);
+        middle_conn = middle_click_gesture->signal_released().connect(show_quick_target_action);
     }
 
     if (str_wp_middle_click_action.value() == "mute_quick_target")
     {
-        middle_conn = middle_click_gesture->signal_pressed().connect(mute_action);
+        middle_conn = middle_click_gesture->signal_released().connect(mute_action);
     }
 
     if (str_wp_right_click_action.value() == "show_mixer")
     {
-        right_conn = right_click_gesture->signal_pressed().connect(show_mixer_action);
+        button->open_on(2);
+        right_conn = right_click_gesture->signal_released().connect(show_mixer_action);
     }
 
     if (str_wp_right_click_action.value() == "show_quick_target")
     {
-        right_conn = right_click_gesture->signal_pressed().connect(show_quick_target_action);
+        right_conn = right_click_gesture->signal_released().connect(show_quick_target_action);
     }
 
     if (str_wp_right_click_action.value() == "mute_quick_target")
     {
-        right_conn = right_click_gesture->signal_pressed().connect(mute_action);
+        right_conn = right_click_gesture->signal_released().connect(mute_action);
     }
 }
 
@@ -345,7 +289,6 @@ void WayfireMixer::set_quick_target_from(MixerControl *from)
 WayfireMixer::~WayfireMixer()
 {
     WpCommon::get().rem_widget(this);
-    popover_timeout.disconnect();
     volume_changed_signal.disconnect();
     left_conn.disconnect();
     middle_conn.disconnect();

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -140,10 +140,6 @@ void WayfireMixer::reload_config()
             if (button->get_popup_child() != (Gtk::Widget*)&master_box)
             {
                 button->set_popup_child(master_box);
-                // popdown so that when the click is processed, the popover is down, and thus pops up
-                // not the prettiest result, as it visibly closes instead of just replacing, but i’m not sure
-                // how to make it better
-                button->popdown();
             }
         });
     }
@@ -163,8 +159,6 @@ void WayfireMixer::reload_config()
             if (button->get_popup_child() != quick_target.get())
             {
                 button->set_popup_child(*quick_target);
-                // same as above
-                button->popdown();
             }
         });
     }

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -50,7 +50,15 @@ void WayfireMixer::reload_config()
     // "actions" that can be bound to different clicks
     auto show_mixer_action = [&] (int c, double x, double y)
     {
-        if (button->get_popup_child() != (Gtk::Widget*)&master_box)
+        if ((button->get_popup_child() == &master_box) && button->is_popup_visible())
+        {
+            button->popdown();
+            return;
+        }
+
+        button->popup();
+
+        if (button->get_popup_child() != &master_box)
         {
             button->set_popup_child(master_box);
         }
@@ -58,7 +66,6 @@ void WayfireMixer::reload_config()
 
     auto show_quick_target_action = [&] (int c, double x, double y)
     {
-        // unschedule hiding
         if (!quick_target)
         {
             return; // no quick_target means we have nothing to show
@@ -70,10 +77,7 @@ void WayfireMixer::reload_config()
             return;
         }
 
-        if (!button->is_popup_visible())
-        {
-            button->popup();
-        }
+        button->popup();
 
         if (button->get_popup_child() != quick_target.get())
         {
@@ -93,7 +97,6 @@ void WayfireMixer::reload_config()
 
     if (str_wp_left_click_action.value() == "show_mixer")
     {
-        button->open_on(1);
         left_conn = left_click_gesture->signal_released().connect(show_mixer_action);
     }
 
@@ -109,7 +112,6 @@ void WayfireMixer::reload_config()
 
     if (str_wp_middle_click_action.value() == "show_mixer")
     {
-        button->open_on(3);
         middle_conn = middle_click_gesture->signal_released().connect(show_mixer_action);
     }
 
@@ -125,7 +127,6 @@ void WayfireMixer::reload_config()
 
     if (str_wp_right_click_action.value() == "show_mixer")
     {
-        button->open_on(2);
         right_conn = right_click_gesture->signal_released().connect(show_mixer_action);
     }
 
@@ -161,7 +162,7 @@ void WayfireMixer::init(Gtk::Box *container)
     button->add_css_class("widget-icon");
     button->append(main_image);
     button->show();
-    button->open_on(1);
+    button->open_on(-1); // the gestures callback will take care of opening and closing
     sinks_box.add_css_class("outputs");
     sources_box.add_css_class("inputs");
     streams_box.add_css_class("streams");

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -11,7 +11,7 @@
 bool WayfireMixer::on_popover_timeout(int timer)
 {
     popover_timeout.disconnect();
-    popover->popdown();
+    button->popdown();
     return false;
 }
 
@@ -73,20 +73,20 @@ void WayfireMixer::reload_config()
         // unschedule hiding
         cancel_popover_timeout();
 
-        if ((popover->get_child() == (Gtk::Widget*)&master_box) && popover->is_visible())
+        if ((button->get_popover_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
         {
-            popover->popdown();
+            button->popdown();
             return;
         }
 
-        if (!popover->is_visible())
+        if (!button->is_popup_visible())
         {
-            button->set_active(true);
+            button->popup();
         }
 
-        if (popover->get_child() != (Gtk::Widget*)&master_box)
+        if (button->get_popover_child() != (Gtk::Widget*)&master_box)
         {
-            popover->set_child(master_box);
+            button->set_popover_child(master_box);
             popover_timeout.disconnect();
         }
     };
@@ -100,20 +100,20 @@ void WayfireMixer::reload_config()
             return; // no quick_target means we have nothing to show
         }
 
-        if ((popover->get_child() == quick_target.get()) && popover->is_visible())
+        if ((button->get_popover_child() == quick_target.get()) && button->is_popup_visible())
         {
-            popover->popdown();
+            button->popdown();
             return;
         }
 
-        if (!popover->is_visible())
+        if (!button->is_popup_visible())
         {
-            button->set_active(true);
+            button->popup();
         }
 
-        if (popover->get_child() != quick_target.get())
+        if (button->get_popover_child() != quick_target.get())
         {
-            popover->set_child(*quick_target);
+            button->set_popover_child(*quick_target);
             popover_timeout.disconnect();
         }
     };
@@ -137,13 +137,13 @@ void WayfireMixer::reload_config()
         {
             // unschedule hiding
             cancel_popover_timeout();
-            if (popover->get_child() != (Gtk::Widget*)&master_box)
+            if (button->get_popover_child() != (Gtk::Widget*)&master_box)
             {
-                popover->set_child(master_box);
+                button->set_popover_child(master_box);
                 // popdown so that when the click is processed, the popover is down, and thus pops up
                 // not the prettiest result, as it visibly closes instead of just replacing, but i’m not sure
                 // how to make it better
-                button->set_active(false);
+                button->popdown();
             }
         });
     }
@@ -160,11 +160,11 @@ void WayfireMixer::reload_config()
                 return;
             }
 
-            if (popover->get_child() != quick_target.get())
+            if (button->get_popover_child() != quick_target.get())
             {
-                popover->set_child(*quick_target);
+                button->set_popover_child(*quick_target);
                 // same as above
-                button->set_active(false);
+                button->popdown();
             }
         });
     }
@@ -219,12 +219,9 @@ void WayfireMixer::init(Gtk::Box *container)
 {
     // sets up the "widget part"
 
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "mixer");
     button->add_css_class("widget-icon");
-    button->add_css_class("mixer");
-    button->add_css_class("flat");
-    button->get_children()[0]->add_css_class("flat");
-    button->set_child(main_image);
+    button->append(main_image);
     button->show();
     sinks_box.add_css_class("outputs");
     sources_box.add_css_class("inputs");
@@ -232,10 +229,7 @@ void WayfireMixer::init(Gtk::Box *container)
     out_in_wall.add_css_class("out-in");
     in_streams_wall.add_css_class("in-streams");
 
-    popover = button->get_popover();
-    popover->set_child(master_box);
-    popover->set_autohide(false);
-    popover->add_css_class("mixer-popover");
+    button->set_popover_child(master_box);
 
     // scroll to change volume of the object targetted by the quick_target widget
     auto scroll_gesture = Gtk::EventControllerScroll::create();
@@ -318,7 +312,6 @@ void WayfireMixer::init(Gtk::Box *container)
 
     // add to the actual container
     container->append(*button);
-    button->set_child(main_image);
 
     // if there is no audio device nor application, the quick target will not be set
     // and the widget will apear empty. Calling this here to always have the OOR icon.
@@ -357,7 +350,6 @@ void WayfireMixer::set_quick_target_from(MixerControl *from)
 WayfireMixer::~WayfireMixer()
 {
     WpCommon::get().rem_widget(this);
-    gtk_widget_unparent(GTK_WIDGET(popover->gobj()));
     popover_timeout.disconnect();
     volume_changed_signal.disconnect();
     left_conn.disconnect();

--- a/src/panel/widgets/mixer/mixer.hpp
+++ b/src/panel/widgets/mixer/mixer.hpp
@@ -54,7 +54,7 @@ class WayfireMixer : public WayfireWidget
     WfOption<bool> invert_scroll{"panel/mixer_invert_scroll"};
     WfOption<bool> popup_on_change{"panel/mixer_popup_on_change"};
 
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
 
     /*
      * the "quick_target" is the representation of the audio channel that shows it’s volume

--- a/src/panel/widgets/mixer/mixer.hpp
+++ b/src/panel/widgets/mixer/mixer.hpp
@@ -55,7 +55,6 @@ class WayfireMixer : public WayfireWidget
     WfOption<bool> popup_on_change{"panel/mixer_popup_on_change"};
 
     std::unique_ptr<WayfireMenuButton> button;
-    Gtk::Popover *popover;
 
     /*
      * the "quick_target" is the representation of the audio channel that shows it’s volume

--- a/src/panel/widgets/mixer/mixer.hpp
+++ b/src/panel/widgets/mixer/mixer.hpp
@@ -30,16 +30,14 @@ class WayfireMixer : public WayfireWidget
 
     WfOption<int> spacing{"panel/mixer_spacing"};
     WfOption<bool> stack_categories{"panel/mixer_stack_categories"};
-    WfOption<double> timeout{"panel/mixer_popup_timeout"};
 
     void on_volume_value_changed();
-    bool on_popover_timeout(int timer);
 
     // signals and gestures for the configurable actions on click
     gulong notify_volume_signal   = 0;
     gulong notify_is_muted_signal = 0;
     gulong notify_default_sink_changed = 0;
-    sigc::connection popover_timeout, volume_changed_signal, left_conn, middle_conn, right_conn, scroll_conn;
+    sigc::connection volume_changed_signal, left_conn, middle_conn, right_conn, scroll_conn;
     std::shared_ptr<Gtk::GestureClick> left_click_gesture, middle_click_gesture, right_click_gesture;
 
     // widgets for the mixer itself
@@ -53,6 +51,7 @@ class WayfireMixer : public WayfireWidget
     WfOption<double> scroll_sensitivity{"panel/mixer_scroll_sensitivity"};
     WfOption<bool> invert_scroll{"panel/mixer_invert_scroll"};
     WfOption<bool> popup_on_change{"panel/mixer_popup_on_change"};
+    WfOption<double> timeout{"panel/mixer_popup_timeout"};
 
     std::unique_ptr<WayfireMenuWidget> button;
 
@@ -72,14 +71,6 @@ class WayfireMixer : public WayfireWidget
 
     /** Update the icon based on volume and muted state of the quick_target widget */
     void update_icon();
-
-    /**
-     * Check whether the popover should be auto-hidden, and if yes, start a timer to hide it
-     */
-    void check_set_popover_timeout();
-
-    // cancel popover self-hiding. mostly used after user interactions to an externally opened popover
-    void cancel_popover_timeout();
 
     void handle_config_reload() override;
 

--- a/src/panel/widgets/mixer/wp-common.cpp
+++ b/src/panel/widgets/mixer/wp-common.cpp
@@ -176,10 +176,10 @@ void WpCommon::add_object_to_widget(WpPipewireObject *object, WayfireMixer *widg
     {
         widget->set_quick_target_from(control);
         // if the full mixer is not shown, change the popover child
-        if ((widget->button->get_popover_child() !=
+        if ((widget->button->get_popup_child() !=
              &(widget->master_box)) && widget->button->is_popup_visible())
         {
-            widget->button->set_popover_child(*widget->quick_target);
+            widget->button->set_popup_child(*widget->quick_target);
         }
 
         widget->update_icon();
@@ -273,7 +273,7 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
         update_icons();
 
         // if the mixer is currently being displayed, stop there
-        if ((widget->button->get_popover_child() ==
+        if ((widget->button->get_popup_child() ==
              &(widget->master_box)) && widget->button->is_popup_visible())
         {
             continue;
@@ -281,10 +281,10 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
 
         if (widget->quick_target &&
             (!widget->button->is_popup_visible() ||
-             (widget->button->get_popover_child() != (MixerControl*)&widget->quick_target)))
+             (widget->button->get_popup_child() != (MixerControl*)&widget->quick_target)))
         {
             // put the quick_target in the popover and show
-            widget->button->set_popover_child(*widget->quick_target);
+            widget->button->set_popup_child(*widget->quick_target);
             if (widget->popup_on_change && change)
             {
                 widget->button->popup();

--- a/src/panel/widgets/mixer/wp-common.cpp
+++ b/src/panel/widgets/mixer/wp-common.cpp
@@ -287,12 +287,9 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
             widget->button->set_popup_child(*widget->quick_target);
             if (widget->popup_on_change && change)
             {
-                widget->button->popup();
+                widget->button->popup_timed(widget->timeout * 1000);
             }
         }
-
-        // in all cases that reach here, (re-)schedule hiding
-        widget->check_set_popover_timeout();
     }
 }
 

--- a/src/panel/widgets/mixer/wp-common.cpp
+++ b/src/panel/widgets/mixer/wp-common.cpp
@@ -176,10 +176,10 @@ void WpCommon::add_object_to_widget(WpPipewireObject *object, WayfireMixer *widg
     {
         widget->set_quick_target_from(control);
         // if the full mixer is not shown, change the popover child
-        if ((widget->popover->get_child() !=
-             &(widget->master_box)) && widget->popover->is_visible())
+        if ((widget->button->get_popover_child() !=
+             &(widget->master_box)) && widget->button->is_popup_visible())
         {
-            widget->popover->set_child(*widget->quick_target);
+            widget->button->set_popover_child(*widget->quick_target);
         }
 
         widget->update_icon();
@@ -273,21 +273,21 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
         update_icons();
 
         // if the mixer is currently being displayed, stop there
-        if ((widget->popover->get_child() ==
-             &(widget->master_box)) && widget->popover->is_visible())
+        if ((widget->button->get_popover_child() ==
+             &(widget->master_box)) && widget->button->is_popup_visible())
         {
             continue;
         }
 
         if (widget->quick_target &&
-            (!widget->popover->is_visible() ||
-             (widget->popover->get_child() != (MixerControl*)&widget->quick_target)))
+            (!widget->button->is_popup_visible() ||
+             (widget->button->get_popover_child() != (MixerControl*)&widget->quick_target)))
         {
             // put the quick_target in the popover and show
-            widget->popover->set_child(*widget->quick_target);
+            widget->button->set_popover_child(*widget->quick_target);
             if (widget->popup_on_change && change)
             {
-                widget->popover->popup();
+                widget->button->popup();
             }
         }
 

--- a/src/panel/widgets/mixer/wp-common.hpp
+++ b/src/panel/widgets/mixer/wp-common.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <vector>
 #include <wp/proxy-interfaces.h>

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -3,6 +3,7 @@
 #include "gtkmm/gestureclick.h"
 #include "gtkmm/gesturelongpress.h"
 #include "network/network.hpp"
+#include "wf-popover.hpp"
 #include <glibmm/spawn.h>
 #include <cassert>
 #include <gtk-utils.hpp>

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -14,7 +14,7 @@ WayfireNetworkInfo::WayfireNetworkInfo()
 void WayfireNetworkInfo::init(Gtk::Box *container)
 {
     network_manager = NetworkManager::getInstance();
-    button = std::make_unique<WayfireMenuButton>("panel", "network");
+    button = std::make_unique<WayfireMenuWidget>("panel", "network");
     button->add_css_class("widget-icon");
     button->add_css_class("flat");
     button->add_css_class("network");
@@ -23,7 +23,7 @@ void WayfireNetworkInfo::init(Gtk::Box *container)
     button->append(button_content);
     button->add_css_class("flat");
 
-    button->set_popover_child(control);
+    button->set_popup_child(control);
 
     button_content.set_valign(Gtk::Align::CENTER);
     button_content.append(icon);

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -30,6 +30,7 @@ void WayfireNetworkInfo::init(Gtk::Box *container)
     button_content.append(icon);
     button_content.append(status);
     button_content.set_spacing(6);
+    button->open_on(1);
 
     icon.set_valign(Gtk::Align::CENTER);
 

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -14,17 +14,16 @@ WayfireNetworkInfo::WayfireNetworkInfo()
 void WayfireNetworkInfo::init(Gtk::Box *container)
 {
     network_manager = NetworkManager::getInstance();
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "network");
     button->add_css_class("widget-icon");
     button->add_css_class("flat");
     button->add_css_class("network");
 
     container->append(*button);
-    button->set_child(button_content);
+    button->append(button_content);
     button->add_css_class("flat");
-    button->set_has_frame(false);
 
-    button->get_popover()->set_child(control);
+    button->set_popover_child(control);
 
     button_content.set_valign(Gtk::Align::CENTER);
     button_content.append(icon);

--- a/src/panel/widgets/network.hpp
+++ b/src/panel/widgets/network.hpp
@@ -18,7 +18,7 @@ class WayfireNetworkInfo : public WayfireWidget
     void on_click();
     std::vector<sigc::connection> signals;
     std::shared_ptr<NetworkManager> network_manager;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     Gtk::Box button_content;
     Gtk::Image icon;
     Gtk::Label status;

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -6,16 +6,17 @@
 #include <gtk-utils.hpp>
 
 #include "single-notification.hpp"
+#include "wf-popover.hpp"
 
 void WayfireNotificationCenter::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel", "notification");
+    button = std::make_unique<WayfireMenuWidget>("panel", "notification");
     icon.add_css_class("widget-icon");
     button->add_css_class("notification-center");
     button->get_children()[0]->add_css_class("flat");
 
     updateIcon();
-    button->set_popover_child(icon);
+    button->set_popup_child(icon);
     container->append(*button);
 
     scrolled_window.set_size_request(WIDTH, HEIGHT);
@@ -23,7 +24,7 @@ void WayfireNotificationCenter::init(Gtk::Box *container)
     box.set_valign(Gtk::Align::START);
     box.set_orientation(Gtk::Orientation::VERTICAL);
     scrolled_window.set_child(box);
-    button->set_popover_child(scrolled_window);
+    button->set_popup_child(scrolled_window);
 
     button->set_tooltip_text("Middle click to toggle DND mode.");
 

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -16,7 +16,8 @@ void WayfireNotificationCenter::init(Gtk::Box *container)
     button->get_children()[0]->add_css_class("flat");
 
     updateIcon();
-    button->set_popup_child(icon);
+    button->append(icon);
+    button->open_on(1);
     container->append(*button);
 
     scrolled_window.set_size_request(WIDTH, HEIGHT);

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -9,23 +9,21 @@
 
 void WayfireNotificationCenter::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "notification");
     icon.add_css_class("widget-icon");
     button->add_css_class("notification-center");
     button->get_children()[0]->add_css_class("flat");
 
     updateIcon();
-    button->set_child(icon);
+    button->set_popover_child(icon);
     container->append(*button);
 
-    auto *popover = button->get_popover();
-    popover->set_size_request(WIDTH, HEIGHT);
-    popover->add_css_class("notification-popover");
+    scrolled_window.set_size_request(WIDTH, HEIGHT);
 
     box.set_valign(Gtk::Align::START);
     box.set_orientation(Gtk::Orientation::VERTICAL);
     scrolled_window.set_child(box);
-    popover->set_child(scrolled_window);
+    button->set_popover_child(scrolled_window);
 
     button->set_tooltip_text("Middle click to toggle DND mode.");
 
@@ -79,14 +77,13 @@ void WayfireNotificationCenter::newNotification(Notification::id_type id, bool s
     widget->set_reveal_child();
     if (show_popup && !dnd_enabled || (show_critical_in_dnd && (notification.hints.urgency == 2)))
     {
-        auto *popover = button->get_popover();
-        if ((timeout > 0) && (!popover_timeout.empty() || !popover->is_visible()))
+        if ((timeout > 0) && (!popover_timeout.empty() || !button->is_popup_visible()))
         {
             popover_timeout.disconnect();
             popover_timeout = Glib::signal_timeout().connect(
                 [=]
             {
-                popover->popdown();
+                button->popdown();
                 button->set_keyboard_interactive();
                 popover_timeout.disconnect();
                 return true;
@@ -95,7 +92,7 @@ void WayfireNotificationCenter::newNotification(Notification::id_type id, bool s
         }
 
         button->set_keyboard_interactive(false);
-        popover->popup();
+        button->popup();
     }
 }
 

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -86,7 +86,7 @@ void WayfireNotificationCenter::newNotification(Notification::id_type id, bool s
                 [=]
             {
                 button->popdown();
-                button->set_keyboard_interactive();
+                button->set_keyboard_interactive(false);
                 popover_timeout.disconnect();
                 return true;
             },

--- a/src/panel/widgets/notifications/notification-center.hpp
+++ b/src/panel/widgets/notifications/notification-center.hpp
@@ -19,7 +19,7 @@ class WayfireNotificationCenter : public WayfireWidget
     sigc::connection notification_close_conn;
 
     Gtk::Image icon;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     Gtk::ScrolledWindow scrolled_window;
     Gtk::Box box;
 

--- a/src/panel/widgets/tray/item.cpp
+++ b/src/panel/widgets/tray/item.cpp
@@ -1,4 +1,5 @@
 #include "item.hpp"
+#include "wf-popover.hpp"
 
 #include <gtk-utils.hpp>
 
@@ -49,9 +50,12 @@ static Glib::RefPtr<Gdk::Pixbuf> extract_pixbuf(IconData && pixbuf_data)
         4 * width, [data_ptr] (auto*) { delete data_ptr; });
 }
 
-StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service)
+StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service) :
+    WayfireMenuWidget("panel",
+        "tray-button",
+        "tray_button")
 {
-    set_child(icon);
+    append(icon);
     menu = std::make_shared<DbusMenuModel>();
 
     const auto & [name, path] = name_and_obj_path(service);
@@ -68,15 +72,6 @@ StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service)
     });
 }
 
-StatusNotifierItem::~StatusNotifierItem()
-{
-    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
-    for (auto signal : signals)
-    {
-        signal.disconnect();
-    }
-}
-
 void StatusNotifierItem::init_widget()
 {
     update_icon();
@@ -84,8 +79,6 @@ void StatusNotifierItem::init_widget()
     init_menu();
     add_css_class("widget-icon");
     add_css_class("tray-button");
-    add_css_class("flat");
-    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(gobj()));
 
     auto scroll_gesture = Gtk::EventControllerScroll::create();
     scroll_gesture->set_flags(Gtk::EventControllerScroll::Flags::BOTH_AXES);
@@ -103,7 +96,7 @@ void StatusNotifierItem::init_widget()
     long_press->signal_pressed().connect(
         [=] (double x, double y)
     {
-        popover.popup();
+        popup();
         long_press->set_state(Gtk::EventSequenceState::CLAIMED);
         click_gesture->set_state(Gtk::EventSequenceState::DENIED);
     });
@@ -127,7 +120,7 @@ void StatusNotifierItem::init_widget()
             {
                 if (has_menu)
                 {
-                    popover.popup();
+                    popup();
                 } else
                 {
                     item_proxy->call("ContextMenu", ev_coords);
@@ -140,7 +133,7 @@ void StatusNotifierItem::init_widget()
         {
             if (has_menu)
             {
-                popover.popup();
+                popup();
             } else
             {
                 item_proxy->call("ContextMenu", ev_coords);
@@ -238,7 +231,7 @@ void StatusNotifierItem::init_menu()
     {
         auto action_group = menu->get_action_group();
         insert_action_group(action_prefix, action_group);
-        popover.set_menu_model(menu->get_menu());
+        set_menu_model(menu->get_menu());
     }));
     has_menu = true;
 }

--- a/src/panel/widgets/tray/item.cpp
+++ b/src/panel/widgets/tray/item.cpp
@@ -1,4 +1,5 @@
 #include "item.hpp"
+#include "wf-popover.hpp"
 
 #include <gtk-utils.hpp>
 
@@ -49,9 +50,12 @@ static Glib::RefPtr<Gdk::Pixbuf> extract_pixbuf(IconData && pixbuf_data)
         4 * width, [data_ptr] (auto*) { delete data_ptr; });
 }
 
-StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service)
+StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service) :
+    WayfireMenuWidget("panel",
+        "tray-button",
+        "tray_button")
 {
-    set_child(icon);
+    append(icon);
     menu = std::make_shared<DbusMenuModel>();
 
     const auto & [name, path] = name_and_obj_path(service);
@@ -68,15 +72,6 @@ StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service)
     });
 }
 
-StatusNotifierItem::~StatusNotifierItem()
-{
-    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
-    for (auto signal : signals)
-    {
-        signal.disconnect();
-    }
-}
-
 void StatusNotifierItem::init_widget()
 {
     update_icon();
@@ -84,8 +79,6 @@ void StatusNotifierItem::init_widget()
     init_menu();
     add_css_class("widget-icon");
     add_css_class("tray-button");
-    add_css_class("flat");
-    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(gobj()));
 
     auto scroll_gesture = Gtk::EventControllerScroll::create();
     scroll_gesture->set_flags(Gtk::EventControllerScroll::Flags::BOTH_AXES);
@@ -103,7 +96,7 @@ void StatusNotifierItem::init_widget()
     long_press->signal_pressed().connect(
         [=] (double x, double y)
     {
-        popover.popup();
+        popup();
         long_press->set_state(Gtk::EventSequenceState::CLAIMED);
         click_gesture->set_state(Gtk::EventSequenceState::DENIED);
     });
@@ -127,7 +120,7 @@ void StatusNotifierItem::init_widget()
             {
                 if (has_menu)
                 {
-                    popover.popup();
+                    popup();
                 } else
                 {
                     item_proxy->call("ContextMenu", ev_coords);
@@ -140,7 +133,7 @@ void StatusNotifierItem::init_widget()
         {
             if (has_menu)
             {
-                popover.popup();
+                popup();
             } else
             {
                 item_proxy->call("ContextMenu", ev_coords);
@@ -229,7 +222,7 @@ void StatusNotifierItem::init_menu()
     {
         auto action_group = menu->get_action_group();
         insert_action_group(action_prefix, action_group);
-        popover.set_menu_model(menu->get_menu());
+        set_menu_model(menu->get_menu());
     }));
     has_menu = true;
 }

--- a/src/panel/widgets/tray/item.hpp
+++ b/src/panel/widgets/tray/item.hpp
@@ -9,8 +9,9 @@
 #include <string>
 
 #include "dbusmenu.hpp"
+#include "wf-popover.hpp"
 
-class StatusNotifierItem : public Gtk::Button
+class StatusNotifierItem : public WayfireMenuWidget
 {
     guint menu_handler_id;
 
@@ -21,7 +22,6 @@ class StatusNotifierItem : public Gtk::Button
 
     Glib::RefPtr<Gio::DBus::Proxy> item_proxy;
 
-    Gtk::PopoverMenu popover;
     std::shared_ptr<DbusMenuModel> menu;
 
     bool has_menu = false;
@@ -60,6 +60,5 @@ class StatusNotifierItem : public Gtk::Button
   public:
     void menu_update(DbusmenuClient *client);
     explicit StatusNotifierItem(const Glib::ustring & service);
-    ~StatusNotifierItem();
     std::string get_unique_name();
 };

--- a/src/panel/widgets/tray/item.hpp
+++ b/src/panel/widgets/tray/item.hpp
@@ -9,8 +9,9 @@
 #include <string>
 
 #include "dbusmenu.hpp"
+#include "wf-popover.hpp"
 
-class StatusNotifierItem : public Gtk::Button
+class StatusNotifierItem : public WayfireMenuWidget
 {
     guint menu_handler_id;
 
@@ -20,7 +21,6 @@ class StatusNotifierItem : public Gtk::Button
 
     Glib::RefPtr<Gio::DBus::Proxy> item_proxy;
 
-    Gtk::PopoverMenu popover;
     std::shared_ptr<DbusMenuModel> menu;
 
     bool has_menu = false;
@@ -57,6 +57,5 @@ class StatusNotifierItem : public Gtk::Button
   public:
     void menu_update(DbusmenuClient *client);
     explicit StatusNotifierItem(const Glib::ustring & service);
-    ~StatusNotifierItem();
     std::string get_unique_name();
 };

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -19,7 +19,7 @@ void WayfireVolume::update_icon()
 
 bool WayfireVolume::on_popover_timeout(int timer)
 {
-    popover->popdown();
+    button->popdown();
     return false;
 }
 
@@ -42,9 +42,9 @@ void WayfireVolume::set_volume(pa_volume_t volume, set_volume_flags_t flags)
 
     if (flags & VOLUME_FLAG_SHOW_POPOVER)
     {
-        if (!popover->is_visible())
+        if (!button->is_popup_visible())
         {
-            popover->popup();
+            button->popup();
         } else
         {
             check_set_popover_timeout();
@@ -137,7 +137,7 @@ void WayfireVolume::on_volume_value_changed()
 
 void WayfireVolume::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "volume");
 
     /* Setup button */
     button->add_css_class("widget-icon");
@@ -168,10 +168,7 @@ void WayfireVolume::init(Gtk::Box *container)
     button->add_controller(scroll_gesture);
 
     /* Setup popover */
-    popover = button->get_popover();
-    popover->set_autohide(false);
-    popover->set_child(volume_scale);
-    popover->add_css_class("volume-popover");
+    button->set_popover_child(volume_scale);
 
     auto scroll_gesture2 = Gtk::EventControllerScroll::create();
     signals.push_back(scroll_gesture2->signal_scroll().connect([=] (double dx, double dy)
@@ -217,13 +214,13 @@ void WayfireVolume::init(Gtk::Box *container)
     });
     left_click_gesture->signal_released().connect([=] (int count, double x, double y)
     {
-        if (popover->is_visible())
+        if (button->is_popup_visible())
         {
-            popover->popdown();
+            button->popdown();
             popover_timeout.disconnect();
         } else
         {
-            popover->popup();
+            button->popup();
             check_set_popover_timeout();
         }
     });
@@ -258,12 +255,11 @@ void WayfireVolume::init(Gtk::Box *container)
 
     /* Setup layout */
     container->append(*button);
-    button->set_child(main_image);
+    button->set_popover_child(main_image);
 }
 
 WayfireVolume::~WayfireVolume()
 {
-    gtk_widget_unparent(GTK_WIDGET(popover->gobj()));
     disconnect_gvc_stream_signals();
 
     if (notify_default_sink_changed)

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -1,7 +1,9 @@
 #include <gtkmm.h>
 #include <glibmm.h>
-
 #include "volume.hpp"
+#include "glib.h"
+#include "glibmm/main.h"
+#include "gtkmm/gesture.h"
 #include "icon-select.hpp"
 #include "wf-popover.hpp"
 
@@ -18,20 +20,6 @@ void WayfireVolume::update_icon()
     main_image.set_from_icon_name(ICON(volume_scale.get_target_value() / (double)max_norm));
 }
 
-bool WayfireVolume::on_popover_timeout(int timer)
-{
-    button->popdown();
-    return false;
-}
-
-void WayfireVolume::check_set_popover_timeout()
-{
-    popover_timeout.disconnect();
-
-    popover_timeout = Glib::signal_timeout().connect(sigc::bind(sigc::mem_fun(*this,
-        &WayfireVolume::on_popover_timeout), 0), timeout * 1000);
-}
-
 void WayfireVolume::set_volume(pa_volume_t volume, set_volume_flags_t flags)
 {
     volume_scale.set_target_value(volume);
@@ -39,17 +27,6 @@ void WayfireVolume::set_volume(pa_volume_t volume, set_volume_flags_t flags)
     {
         gvc_mixer_stream_set_volume(gvc_stream, volume);
         gvc_mixer_stream_push_volume(gvc_stream);
-    }
-
-    if (flags & VOLUME_FLAG_SHOW_POPOVER)
-    {
-        if (!button->is_popup_visible())
-        {
-            button->popup();
-        } else
-        {
-            check_set_popover_timeout();
-        }
     }
 
     update_icon();
@@ -63,7 +40,11 @@ void WayfireVolume::on_volume_changed_external()
         set_volume(volume, VOLUME_FLAG_SHOW_POPOVER);
     }
 
-    check_set_popover_timeout();
+    Glib::signal_idle().connect([=] ()
+    {
+        button->popup_timed(timeout * 1000);
+        return G_SOURCE_REMOVE;
+    });
 }
 
 static void notify_volume(GvcMixerControl *gvc_control,
@@ -138,16 +119,30 @@ void WayfireVolume::on_volume_value_changed()
 
 void WayfireVolume::init(Gtk::Box *container)
 {
+    main_image.add_css_class("widget-icon");
     button = std::make_unique<WayfireMenuWidget>("panel", "volume");
+    button->set_keyboard_interactive(false);
 
-    /* Setup button */
-    button->add_css_class("widget-icon");
-    button->add_css_class("volume");
-    button->add_css_class("flat");
-    button->get_children()[0]->add_css_class("flat");
-
+    auto middle_click_gesture = Gtk::GestureClick::create();
+    auto long_press     = Gtk::GestureLongPress::create();
     auto scroll_gesture = Gtk::EventControllerScroll::create();
-    scroll_gesture->signal_scroll().connect([=] (double dx, double dy)
+    auto scroll_gesture2 = Gtk::EventControllerScroll::create();
+
+    scroll_gesture->set_flags(Gtk::EventControllerScroll::Flags::VERTICAL);
+    scroll_gesture->set_propagation_phase(Gtk::PropagationPhase::CAPTURE);
+    scroll_gesture2->set_flags(Gtk::EventControllerScroll::Flags::VERTICAL);
+    scroll_gesture2->set_propagation_phase(Gtk::PropagationPhase::CAPTURE);
+
+    long_press->set_touch_only(true);
+    middle_click_gesture->set_button(2);
+
+    /* Setup gvc control */
+    gvc_control = gvc_mixer_control_new("Wayfire Volume Control");
+    notify_default_sink_changed = g_signal_connect(gvc_control,
+        "default-sink-changed", G_CALLBACK(default_sink_changed), this);
+    gvc_mixer_control_open(gvc_control);
+
+    signals.push_back(scroll_gesture->signal_scroll().connect([=] (double dx, double dy)
     {
         int change = 0;
         if (scroll_gesture->get_unit() == Gdk::ScrollUnit::WHEEL)
@@ -163,15 +158,7 @@ void WayfireVolume::init(Gtk::Box *container)
         set_volume(std::clamp(volume_scale.get_target_value() - change,
             0.0, max_norm));
         return true;
-    }, true);
-    scroll_gesture->set_flags(Gtk::EventControllerScroll::Flags::VERTICAL);
-    scroll_gesture->set_propagation_phase(Gtk::PropagationPhase::CAPTURE);
-    button->add_controller(scroll_gesture);
-
-    /* Setup popover */
-    button->set_popup_child(volume_scale);
-
-    auto scroll_gesture2 = Gtk::EventControllerScroll::create();
+    }, true));
     signals.push_back(scroll_gesture2->signal_scroll().connect([=] (double dx, double dy)
     {
         int change = 0;
@@ -189,48 +176,7 @@ void WayfireVolume::init(Gtk::Box *container)
             0.0, max_norm));
         return true;
     }, false));
-    scroll_gesture2->set_flags(Gtk::EventControllerScroll::Flags::VERTICAL);
-    scroll_gesture2->set_propagation_phase(Gtk::PropagationPhase::CAPTURE);
-    volume_scale.add_controller(scroll_gesture2);
-
-    volume_scale.set_draw_value(false);
-    volume_scale.set_size_request(300, 0);
-    volume_scale.set_user_changed_callback([=] () { on_volume_value_changed(); });
-
-    signals.push_back(volume_scale.signal_state_flags_changed().connect(
-        [=] (Gtk::StateFlags) { check_set_popover_timeout(); }));
-
-    /* Setup gvc control */
-    gvc_control = gvc_mixer_control_new("Wayfire Volume Control");
-    notify_default_sink_changed = g_signal_connect(gvc_control,
-        "default-sink-changed", G_CALLBACK(default_sink_changed), this);
-    gvc_mixer_control_open(gvc_control);
-
-    /* Ensure left click reliably toggles scale popover */
-    auto left_click_gesture = Gtk::GestureClick::create();
-    left_click_gesture->set_button(1);
-    left_click_gesture->signal_pressed().connect([=] (int count, double x, double y)
-    {
-        left_click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
-    });
-    left_click_gesture->signal_released().connect([=] (int count, double x, double y)
-    {
-        if (button->is_popup_visible())
-        {
-            button->popdown();
-            popover_timeout.disconnect();
-        } else
-        {
-            button->popup();
-            check_set_popover_timeout();
-        }
-    });
-
-    /* Middle click toggle mute */
-    auto middle_click_gesture = Gtk::GestureClick::create();
-    auto long_press = Gtk::GestureLongPress::create();
-    long_press->set_touch_only(true);
-    long_press->signal_pressed().connect(
+    signals.push_back(long_press->signal_pressed().connect(
         [=] (double x, double y)
     {
         bool muted = !(gvc_stream && gvc_mixer_stream_get_is_muted(gvc_stream));
@@ -238,8 +184,7 @@ void WayfireVolume::init(Gtk::Box *container)
         gvc_mixer_stream_push_volume(gvc_stream);
         long_press->set_state(Gtk::EventSequenceState::CLAIMED);
         middle_click_gesture->set_state(Gtk::EventSequenceState::DENIED);
-    });
-    middle_click_gesture->set_button(2);
+    }));
     signals.push_back(middle_click_gesture->signal_pressed().connect([=] (int count, double x, double y)
     {
         middle_click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
@@ -250,13 +195,20 @@ void WayfireVolume::init(Gtk::Box *container)
         gvc_mixer_stream_change_is_muted(gvc_stream, muted);
         gvc_mixer_stream_push_volume(gvc_stream);
     }));
+
+    volume_scale.set_draw_value(false);
+    volume_scale.set_size_request(300, 0);
+    volume_scale.set_user_changed_callback([=] () { on_volume_value_changed(); });
+    volume_scale.add_controller(scroll_gesture2);
+    // button->add_controller(scroll_gesture);
     button->add_controller(long_press);
-    button->add_controller(left_click_gesture);
     button->add_controller(middle_click_gesture);
+    button->open_on(1);
 
     /* Setup layout */
     container->append(*button);
-    button->set_popup_child(main_image);
+    button->append(main_image);
+    button->set_popup_child(volume_scale);
 }
 
 WayfireVolume::~WayfireVolume()
@@ -270,6 +222,4 @@ WayfireVolume::~WayfireVolume()
 
     gvc_mixer_control_close(gvc_control);
     g_object_unref(gvc_control);
-
-    popover_timeout.disconnect();
 }

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -3,6 +3,7 @@
 
 #include "volume.hpp"
 #include "icon-select.hpp"
+#include "wf-popover.hpp"
 
 #define ICON(volume) icon_from_range(volume_icons, volume)
 
@@ -137,7 +138,7 @@ void WayfireVolume::on_volume_value_changed()
 
 void WayfireVolume::init(Gtk::Box *container)
 {
-    button = std::make_unique<WayfireMenuButton>("panel", "volume");
+    button = std::make_unique<WayfireMenuWidget>("panel", "volume");
 
     /* Setup button */
     button->add_css_class("widget-icon");
@@ -168,7 +169,7 @@ void WayfireVolume::init(Gtk::Box *container)
     button->add_controller(scroll_gesture);
 
     /* Setup popover */
-    button->set_popover_child(volume_scale);
+    button->set_popup_child(volume_scale);
 
     auto scroll_gesture2 = Gtk::EventControllerScroll::create();
     signals.push_back(scroll_gesture2->signal_scroll().connect([=] (double dx, double dy)
@@ -255,7 +256,7 @@ void WayfireVolume::init(Gtk::Box *container)
 
     /* Setup layout */
     container->append(*button);
-    button->set_popover_child(main_image);
+    button->set_popup_child(main_image);
 }
 
 WayfireVolume::~WayfireVolume()

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -209,6 +209,8 @@ void WayfireVolume::init(Gtk::Box *container)
     container->append(*button);
     button->append(main_image);
     button->set_popup_child(volume_scale);
+    /* Override scroll bar as it isn't needed here */
+    button->get_scroll().set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::NEVER);
 }
 
 WayfireVolume::~WayfireVolume()

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -200,7 +200,7 @@ void WayfireVolume::init(Gtk::Box *container)
     volume_scale.set_size_request(300, 0);
     volume_scale.set_user_changed_callback([=] () { on_volume_value_changed(); });
     volume_scale.add_controller(scroll_gesture2);
-    // button->add_controller(scroll_gesture);
+    button->add_controller(scroll_gesture);
     button->add_controller(long_press);
     button->add_controller(middle_click_gesture);
     button->open_on(1);

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -1,9 +1,7 @@
 #include <gtkmm.h>
 #include <glibmm.h>
+
 #include "volume.hpp"
-#include "glib.h"
-#include "glibmm/main.h"
-#include "gtkmm/gesture.h"
 #include "icon-select.hpp"
 #include "wf-popover.hpp"
 

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -14,7 +14,6 @@ class WayfireVolume : public WayfireWidget
     Gtk::Image main_image;
     WayfireAnimatedScale volume_scale;
     std::unique_ptr<WayfireMenuButton> button;
-    Gtk::Popover *popover;
 
     WfOption<double> timeout{"panel/volume_display_timeout"};
     WfOption<double> scroll_sensitivity{"panel/volume_scroll_sensitivity"};

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -21,7 +21,6 @@ class WayfireVolume : public WayfireWidget
     // void on_volume_scroll(GdkEventScroll *event);
     // void on_volume_button_press(GdkEventButton *event);
     void on_volume_value_changed();
-    bool on_popover_timeout(int timer);
 
     GvcMixerControl *gvc_control;
     GvcMixerStream *gvc_stream = NULL;
@@ -30,7 +29,6 @@ class WayfireVolume : public WayfireWidget
     gulong notify_volume_signal   = 0;
     gulong notify_is_muted_signal = 0;
     gulong notify_default_sink_changed = 0;
-    sigc::connection popover_timeout;
     std::vector<sigc::connection> signals;
     void disconnect_gvc_stream_signals();
 
@@ -67,9 +65,4 @@ class WayfireVolume : public WayfireWidget
 
     /** Called when the default sink changes */
     void on_default_sink_changed();
-
-    /**
-     * Check whether the popover should be auto-hidden, and if yes, start a timer to hide it
-     */
-    void check_set_popover_timeout();
 };

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -13,7 +13,7 @@ class WayfireVolume : public WayfireWidget
 {
     Gtk::Image main_image;
     WayfireAnimatedScale volume_scale;
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
 
     WfOption<double> timeout{"panel/volume_display_timeout"};
     WfOption<double> scroll_sensitivity{"panel/volume_scroll_sensitivity"};

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -19,7 +19,6 @@ class WayfireVolume : public WayfireWidget
     WfOption<double> scroll_sensitivity{"panel/volume_scroll_sensitivity"};
 
     void on_volume_value_changed();
-    bool on_popover_timeout(int timer);
 
     GvcMixerControl *gvc_control;
     GvcMixerStream *gvc_stream = NULL;
@@ -28,7 +27,6 @@ class WayfireVolume : public WayfireWidget
     gulong notify_volume_signal   = 0;
     gulong notify_is_muted_signal = 0;
     gulong notify_default_sink_changed = 0;
-    sigc::connection popover_timeout;
     std::vector<sigc::connection> signals;
     void disconnect_gvc_stream_signals();
 
@@ -65,9 +63,4 @@ class WayfireVolume : public WayfireWidget
 
     /** Called when the default sink changes */
     void on_default_sink_changed();
-
-    /**
-     * Check whether the popover should be auto-hidden, and if yes, start a timer to hide it
-     */
-    void check_set_popover_timeout();
 };

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -11,6 +11,8 @@
 #include <sys/mman.h>
 
 #include "toplevel.hpp"
+#include "gtkmm/enums.h"
+#include "gtkmm/gesture.h"
 #include "window-list.hpp"
 #include "gtk-utils.hpp"
 
@@ -398,7 +400,6 @@ class WayfireToplevel::impl
     uint32_t state;
     uint64_t view_id;
 
-    Gtk::Button button;
     Gtk::Box custom_tooltip_content;
     TooltipMedia *tooltip_media;
     Glib::RefPtr<Gio::SimpleActionGroup> actions;
@@ -408,7 +409,7 @@ class WayfireToplevel::impl
     Glib::RefPtr<Gio::MenuItem> minimize, maximize, close;
     Glib::RefPtr<Gio::SimpleAction> minimize_action, maximize_action, close_action;
     // Gtk::Box menu_box;
-    Gtk::Box button_contents;
+    Gtk::Box button;
     Gtk::Image image;
     Gtk::Label label;
     // Gtk::PopoverMenu menu;
@@ -432,17 +433,16 @@ class WayfireToplevel::impl
             &toplevel_handle_v1_impl, this);
 
         button.add_css_class("window-button");
-        button.add_css_class("flat");
         button.remove_css_class("activated");
-        button_contents.append(image);
-        button_contents.append(label);
-        button_contents.set_halign(Gtk::Align::START);
-        button_contents.set_hexpand(true);
-        button_contents.set_spacing(5);
-        button.set_child(button_contents);
+        button.append(image);
+        button.append(label);
+        button.set_halign(Gtk::Align::FILL);
+        button.set_hexpand(true);
+        button.set_spacing(5);
 
         label.set_ellipsize(Pango::EllipsizeMode::END);
         label.set_hexpand(true);
+        label.set_halign(Gtk::Align::START);
 
         button.property_scale_factor().signal_changed()
             .connect(sigc::mem_fun(*this, &WayfireToplevel::impl::on_scale_update));
@@ -463,8 +463,6 @@ class WayfireToplevel::impl
         actions->add_action(minimize_action);
         actions->add_action(maximize_action);
 
-        // Hey Kids, want to see a really stupid idea?
-        // Button can only have one child! But setting the parent of a popover still works fine...
         gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(button.gobj()));
 
         popover.insert_action_group("windowaction", actions);
@@ -493,16 +491,16 @@ class WayfireToplevel::impl
         signals.push_back(long_press->signal_pressed().connect(
             [=] (double x, double y)
         {
-            popover.popup();
+            drag_exceeds_threshold = true; /* A lie, but fixes long touch again */
             long_press->set_state(Gtk::EventSequenceState::CLAIMED);
             click_gesture->set_state(Gtk::EventSequenceState::DENIED);
+            drag_gesture->set_state(Gtk::EventSequenceState::DENIED);
+            popover.popup();
         }));
         click_gesture->set_button(0);
         signals.push_back(click_gesture->signal_pressed().connect(
             [=] (int count, double x, double y)
-        {
-            click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
-        }));
+        {}));
 
         signals.push_back(click_gesture->signal_released().connect(
             [=] (int count, double x, double y)
@@ -980,10 +978,8 @@ class WayfireToplevel::impl
         if (state & WF_TOPLEVEL_STATE_ACTIVATED)
         {
             button.add_css_class("activated");
-            button.remove_css_class("flat");
         } else
         {
-            button.add_css_class("flat");
             button.remove_css_class("activated");
         }
 

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -10,8 +10,6 @@
 #include <sys/mman.h>
 
 #include "toplevel.hpp"
-#include "gtkmm/enums.h"
-#include "gtkmm/gesture.h"
 #include "window-list.hpp"
 #include "gtk-utils.hpp"
 

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -10,6 +10,8 @@
 #include <sys/mman.h>
 
 #include "toplevel.hpp"
+#include "gtkmm/enums.h"
+#include "gtkmm/gesture.h"
 #include "window-list.hpp"
 #include "gtk-utils.hpp"
 
@@ -391,7 +393,6 @@ class WayfireToplevel::impl
     uint32_t state;
     uint64_t view_id;
 
-    Gtk::Button button;
     Gtk::Box custom_tooltip_content;
     TooltipMedia *tooltip_media;
     Glib::RefPtr<Gio::SimpleActionGroup> actions;
@@ -400,7 +401,7 @@ class WayfireToplevel::impl
     Glib::RefPtr<Gio::Menu> menu;
     Glib::RefPtr<Gio::MenuItem> minimize, maximize, close;
     Glib::RefPtr<Gio::SimpleAction> minimize_action, maximize_action, close_action;
-    Gtk::Box button_contents;
+    Gtk::Box button;
     Gtk::Image image;
     Gtk::Label label;
     Glib::RefPtr<Gtk::GestureDrag> drag_gesture;
@@ -423,17 +424,16 @@ class WayfireToplevel::impl
             &toplevel_handle_v1_impl, this);
 
         button.add_css_class("window-button");
-        button.add_css_class("flat");
         button.remove_css_class("activated");
-        button_contents.append(image);
-        button_contents.append(label);
-        button_contents.set_halign(Gtk::Align::START);
-        button_contents.set_hexpand(true);
-        button_contents.set_spacing(5);
-        button.set_child(button_contents);
+        button.append(image);
+        button.append(label);
+        button.set_halign(Gtk::Align::FILL);
+        button.set_hexpand(true);
+        button.set_spacing(5);
 
         label.set_ellipsize(Pango::EllipsizeMode::END);
         label.set_hexpand(true);
+        label.set_halign(Gtk::Align::START);
 
         button.property_scale_factor().signal_changed()
             .connect(sigc::mem_fun(*this, &WayfireToplevel::impl::on_scale_update));
@@ -454,8 +454,6 @@ class WayfireToplevel::impl
         actions->add_action(minimize_action);
         actions->add_action(maximize_action);
 
-        // Hey Kids, want to see a really stupid idea?
-        // Button can only have one child! But setting the parent of a popover still works fine...
         gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(button.gobj()));
 
         popover.insert_action_group("windowaction", actions);
@@ -484,16 +482,16 @@ class WayfireToplevel::impl
         signals.push_back(long_press->signal_pressed().connect(
             [=] (double x, double y)
         {
-            popover.popup();
+            drag_exceeds_threshold = true; /* A lie, but fixes long touch again */
             long_press->set_state(Gtk::EventSequenceState::CLAIMED);
             click_gesture->set_state(Gtk::EventSequenceState::DENIED);
+            drag_gesture->set_state(Gtk::EventSequenceState::DENIED);
+            popover.popup();
         }));
         click_gesture->set_button(0);
         signals.push_back(click_gesture->signal_pressed().connect(
             [=] (int count, double x, double y)
-        {
-            click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
-        }));
+        {}));
 
         signals.push_back(click_gesture->signal_released().connect(
             [=] (int count, double x, double y)
@@ -970,10 +968,8 @@ class WayfireToplevel::impl
         if (state & WF_TOPLEVEL_STATE_ACTIVATED)
         {
             button.add_css_class("activated");
-            button.remove_css_class("flat");
         } else
         {
-            button.add_css_class("flat");
             button.remove_css_class("activated");
         }
 

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -20,9 +20,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
     box.add_css_class("workspace-switcher");
     box.add_css_class("flat");
 
-    button = std::make_unique<WayfireMenuButton>("panel");
-    button->get_children()[0]->add_css_class("flat");
-    button->get_children()[0]->add_css_class("workspace-switcher");
+    button = std::make_unique<WayfireMenuButton>("panel", "workspace-switcher", "workspace_switcher");
 
     ipc_client->subscribe(this, {"view-mapped"});
     ipc_client->subscribe(this, {"view-focused"});
@@ -51,8 +49,8 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
             switcher_box.append(overlay);
         } else // "grid_popover"
         {
-            button->get_popover()->set_child(overlay);
-            button->set_child(mini_grid);
+            button->set_popover_child(overlay);
+            button->append(mini_grid);
             switcher_box.append(*button);
         }
 
@@ -474,8 +472,7 @@ void WayfireWorkspaceSwitcher::grid_process_workspaces(wf::json_t workspace_data
                 }
 
                 clear_box();
-                button->m_popover.set_parent(mini_grid);
-                button->m_popover.set_child(overlay);
+                button->set_popover_child(overlay);
                 overlay.set_child(switch_grid);
                 overlay.add_css_class("workspace");
                 overlay.signal_get_child_position().connect(sigc::mem_fun(*this,

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -5,6 +5,7 @@
 #include <wf-option-wrap.hpp>
 
 #include "panel.hpp"
+#include "wf-popover.hpp"
 #include "workspace-switcher.hpp"
 
 void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
@@ -20,7 +21,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
     box.add_css_class("workspace-switcher");
     box.add_css_class("flat");
 
-    button = std::make_unique<WayfireMenuButton>("panel", "workspace-switcher", "workspace_switcher");
+    button = std::make_unique<WayfireMenuWidget>("panel", "workspace-switcher", "workspace_switcher");
 
     ipc_client->subscribe(this, {"view-mapped"});
     ipc_client->subscribe(this, {"view-focused"});
@@ -49,7 +50,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
             switcher_box.append(overlay);
         } else // "grid_popover"
         {
-            button->set_popover_child(overlay);
+            button->set_popup_child(overlay);
             button->append(mini_grid);
             switcher_box.append(*button);
         }
@@ -472,7 +473,7 @@ void WayfireWorkspaceSwitcher::grid_process_workspaces(wf::json_t workspace_data
                 }
 
                 clear_box();
-                button->set_popover_child(overlay);
+                button->set_popup_child(overlay);
                 overlay.set_child(switch_grid);
                 overlay.add_css_class("workspace");
                 overlay.signal_get_child_position().connect(sigc::mem_fun(*this,

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -5,6 +5,7 @@
 #include <wf-option-wrap.hpp>
 
 #include "panel.hpp"
+#include "wf-popover.hpp"
 #include "workspace-switcher.hpp"
 
 void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
@@ -20,7 +21,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
     box.add_css_class("workspace-switcher");
     box.add_css_class("flat");
 
-    button = std::make_unique<WayfireMenuButton>("panel", "workspace-switcher", "workspace_switcher");
+    button = std::make_unique<WayfireMenuWidget>("panel", "workspace-switcher", "workspace_switcher");
 
     ipc_client->subscribe(this, {"view-mapped"});
     ipc_client->subscribe(this, {"view-focused"});
@@ -49,7 +50,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
             switcher_box.append(overlay);
         } else // "grid_popover"
         {
-            button->set_popover_child(overlay);
+            button->set_popup_child(overlay);
             button->append(mini_grid);
             switcher_box.append(*button);
         }
@@ -449,7 +450,7 @@ void WayfireWorkspaceSwitcher::grid_process_workspaces(wf::json_t workspace_data
                 }
 
                 clear_box();
-                button->set_popover_child(overlay);
+                button->set_popup_child(overlay);
                 overlay.set_child(switch_grid);
                 overlay.add_css_class("workspace");
                 overlay.signal_get_child_position().connect(sigc::mem_fun(*this,

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -45,14 +45,17 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
         if (workspace_switcher_mode.value() == "row")
         {
             switcher_box.append(box);
+            button->open_on(-1);
         } else if (workspace_switcher_mode.value() == "grid")
         {
             switcher_box.append(overlay);
+            button->open_on(-1);
         } else // "grid_popover"
         {
             button->set_popup_child(overlay);
             button->append(mini_grid);
             switcher_box.append(*button);
+            button->open_on(1);
         }
 
         get_wsets();

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -20,9 +20,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
     box.add_css_class("workspace-switcher");
     box.add_css_class("flat");
 
-    button = std::make_unique<WayfireMenuButton>("panel");
-    button->get_children()[0]->add_css_class("flat");
-    button->get_children()[0]->add_css_class("workspace-switcher");
+    button = std::make_unique<WayfireMenuButton>("panel", "workspace-switcher", "workspace_switcher");
 
     ipc_client->subscribe(this, {"view-mapped"});
     ipc_client->subscribe(this, {"view-focused"});
@@ -51,8 +49,8 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
             switcher_box.append(overlay);
         } else // "grid_popover"
         {
-            button->get_popover()->set_child(overlay);
-            button->set_child(mini_grid);
+            button->set_popover_child(overlay);
+            button->append(mini_grid);
             switcher_box.append(*button);
         }
 
@@ -451,8 +449,7 @@ void WayfireWorkspaceSwitcher::grid_process_workspaces(wf::json_t workspace_data
                 }
 
                 clear_box();
-                button->m_popover.set_parent(mini_grid);
-                button->m_popover.set_child(overlay);
+                button->set_popover_child(overlay);
                 overlay.set_child(switch_grid);
                 overlay.add_css_class("workspace");
                 overlay.signal_get_child_position().connect(sigc::mem_fun(*this,

--- a/src/panel/widgets/workspace-switcher.hpp
+++ b/src/panel/widgets/workspace-switcher.hpp
@@ -51,7 +51,7 @@ class WayfireWorkspaceSwitcher : public WayfireWidget, public IIPCSubscriber
     Gtk::Grid switch_grid;
     Gtk::Overlay overlay;
     double get_scaled_width();
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     int output_width, output_height;
     void init(Gtk::Box *container) override;
     WayfireWorkspaceSwitcher(WayfireOutput *output);

--- a/src/panel/widgets/workspace-switcher.hpp
+++ b/src/panel/widgets/workspace-switcher.hpp
@@ -51,7 +51,7 @@ class WayfireWorkspaceSwitcher : public WayfireWidget, public IIPCSubscriber
     Gtk::Grid switch_grid;
     Gtk::Overlay overlay;
     std::pair<double, double> get_scaled_size();
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
     int output_width, output_height;
     void init(Gtk::Box *container) override;
     WayfireWorkspaceSwitcher(WayfireOutput *output);

--- a/src/panel/widgets/wp-mixer/wp-common.cpp
+++ b/src/panel/widgets/wp-mixer/wp-common.cpp
@@ -176,10 +176,10 @@ void WpCommon::add_object_to_widget(WpPipewireObject *object, WayfireWpMixer *wi
     {
         widget->set_quick_target_from(control);
         // if the full mixer is not shown, change the popover child
-        if ((widget->button->get_popover_child() !=
+        if ((widget->button->get_popup_child() !=
              &(widget->master_box)) && widget->button->is_popup_visible())
         {
-            widget->button->set_popover_child(*widget->quick_target);
+            widget->button->set_popup_child(*widget->quick_target);
         }
 
         widget->update_icon();
@@ -275,7 +275,7 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
         update_icons();
 
         // if the mixer is currently being displayed, stop there
-        if ((widget->button->get_popover_child() ==
+        if ((widget->button->get_popup_child() ==
              &(widget->master_box)) && widget->button->is_popup_visible())
         {
             continue;
@@ -283,10 +283,10 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
 
         if (widget->quick_target &&
             (!widget->button->is_popup_visible() ||
-             (widget->button->get_popover_child() != (WfWpControl*)&widget->quick_target)))
+             (widget->button->get_popup_child() != (WfWpControl*)&widget->quick_target)))
         {
             // put the quick_target in the popover and show
-            widget->button->set_popover_child(*widget->quick_target);
+            widget->button->set_popup_child(*widget->quick_target);
             if (widget->popup_on_change && change)
             {
                 widget->button->popup();

--- a/src/panel/widgets/wp-mixer/wp-common.cpp
+++ b/src/panel/widgets/wp-mixer/wp-common.cpp
@@ -176,10 +176,10 @@ void WpCommon::add_object_to_widget(WpPipewireObject *object, WayfireWpMixer *wi
     {
         widget->set_quick_target_from(control);
         // if the full mixer is not shown, change the popover child
-        if ((widget->popover->get_child() !=
-             &(widget->master_box)) && widget->popover->is_visible())
+        if ((widget->button->get_popover_child() !=
+             &(widget->master_box)) && widget->button->is_popup_visible())
         {
-            widget->popover->set_child(*widget->quick_target);
+            widget->button->set_popover_child(*widget->quick_target);
         }
 
         widget->update_icon();
@@ -275,21 +275,21 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
         update_icons();
 
         // if the mixer is currently being displayed, stop there
-        if ((widget->popover->get_child() ==
-             &(widget->master_box)) && widget->popover->is_visible())
+        if ((widget->button->get_popover_child() ==
+             &(widget->master_box)) && widget->button->is_popup_visible())
         {
             continue;
         }
 
         if (widget->quick_target &&
-            (!widget->popover->is_visible() ||
-             (widget->popover->get_child() != (WfWpControl*)&widget->quick_target)))
+            (!widget->button->is_popup_visible() ||
+             (widget->button->get_popover_child() != (WfWpControl*)&widget->quick_target)))
         {
             // put the quick_target in the popover and show
-            widget->popover->set_child(*widget->quick_target);
+            widget->button->set_popover_child(*widget->quick_target);
             if (widget->popup_on_change && change)
             {
-                widget->popover->popup();
+                widget->button->popup();
             }
         }
 

--- a/src/panel/widgets/wp-mixer/wp-common.hpp
+++ b/src/panel/widgets/wp-mixer/wp-common.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <vector>
 #include <wp/proxy-interfaces.h>

--- a/src/panel/widgets/wp-mixer/wp-mixer.cpp
+++ b/src/panel/widgets/wp-mixer/wp-mixer.cpp
@@ -3,6 +3,7 @@
 #include <wp/proxy.h>
 
 #include "wp-mixer.hpp"
+#include "wf-popover.hpp"
 #include "wf-wp-control.hpp"
 #include "icon-select.hpp"
 
@@ -73,7 +74,7 @@ void WayfireWpMixer::reload_config()
         // unschedule hiding
         cancel_popover_timeout();
 
-        if ((button->get_popover_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
+        if ((button->get_popup_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
         {
             button->popdown();
             return;
@@ -84,9 +85,9 @@ void WayfireWpMixer::reload_config()
             button->popup();
         }
 
-        if (button->get_popover_child() != (Gtk::Widget*)&master_box)
+        if (button->get_popup_child() != (Gtk::Widget*)&master_box)
         {
-            button->set_popover_child(master_box);
+            button->set_popup_child(master_box);
             popover_timeout.disconnect();
         }
     };
@@ -100,7 +101,7 @@ void WayfireWpMixer::reload_config()
             return; // no quick_target means we have nothing to show
         }
 
-        if ((button->get_popover_child() == quick_target.get()) && button->is_popup_visible())
+        if ((button->get_popup_child() == quick_target.get()) && button->is_popup_visible())
         {
             button->popdown();
             return;
@@ -111,9 +112,9 @@ void WayfireWpMixer::reload_config()
             button->popup();
         }
 
-        if (button->get_popover_child() != quick_target.get())
+        if (button->get_popup_child() != quick_target.get())
         {
-            button->set_popover_child(*quick_target);
+            button->set_popup_child(*quick_target);
             popover_timeout.disconnect();
         }
     };
@@ -137,9 +138,9 @@ void WayfireWpMixer::reload_config()
         {
             // unschedule hiding
             cancel_popover_timeout();
-            if (button->get_popover_child() != (Gtk::Widget*)&master_box)
+            if (button->get_popup_child() != (Gtk::Widget*)&master_box)
             {
-                button->set_popover_child(master_box);
+                button->set_popup_child(master_box);
                 // popdown so that when the click is processed, the popover is down, and thus pops up
                 // not the prettiest result, as it visibly closes instead of just replacing, but i’m not sure
                 // how to make it better
@@ -160,9 +161,9 @@ void WayfireWpMixer::reload_config()
                 return;
             }
 
-            if (button->get_popover_child() != quick_target.get())
+            if (button->get_popup_child() != quick_target.get())
             {
-                button->set_popover_child(*quick_target);
+                button->set_popup_child(*quick_target);
                 // same as above
                 button->popdown();
             }
@@ -219,17 +220,18 @@ void WayfireWpMixer::init(Gtk::Box *container)
 {
     // sets up the "widget part"
 
-    button = std::make_unique<WayfireMenuButton>("panel", "wp-mixer", "wp_mixer");
+    button = std::make_unique<WayfireMenuWidget>("panel", "wp-mixer", "wp_mixer");
     button->add_css_class("widget-icon");
     button->append(main_image);
     button->show();
+    button->open_on(1);
     sinks_box.add_css_class("outputs");
     sources_box.add_css_class("inputs");
     streams_box.add_css_class("streams");
     out_in_wall.add_css_class("out-in");
     in_streams_wall.add_css_class("in-streams");
 
-    button->set_popover_child(master_box);
+    button->set_popup_child(master_box);
 
     // scroll to change volume of the object targetted by the quick_target widget
     auto scroll_gesture = Gtk::EventControllerScroll::create();

--- a/src/panel/widgets/wp-mixer/wp-mixer.cpp
+++ b/src/panel/widgets/wp-mixer/wp-mixer.cpp
@@ -11,7 +11,7 @@
 bool WayfireWpMixer::on_popover_timeout(int timer)
 {
     popover_timeout.disconnect();
-    popover->popdown();
+    button->popdown();
     return false;
 }
 
@@ -73,20 +73,20 @@ void WayfireWpMixer::reload_config()
         // unschedule hiding
         cancel_popover_timeout();
 
-        if ((popover->get_child() == (Gtk::Widget*)&master_box) && popover->is_visible())
+        if ((button->get_popover_child() == (Gtk::Widget*)&master_box) && button->is_popup_visible())
         {
-            popover->popdown();
+            button->popdown();
             return;
         }
 
-        if (!popover->is_visible())
+        if (!button->is_popup_visible())
         {
-            button->set_active(true);
+            button->popup();
         }
 
-        if (popover->get_child() != (Gtk::Widget*)&master_box)
+        if (button->get_popover_child() != (Gtk::Widget*)&master_box)
         {
-            popover->set_child(master_box);
+            button->set_popover_child(master_box);
             popover_timeout.disconnect();
         }
     };
@@ -100,20 +100,20 @@ void WayfireWpMixer::reload_config()
             return; // no quick_target means we have nothing to show
         }
 
-        if ((popover->get_child() == quick_target.get()) && popover->is_visible())
+        if ((button->get_popover_child() == quick_target.get()) && button->is_popup_visible())
         {
-            popover->popdown();
+            button->popdown();
             return;
         }
 
-        if (!popover->is_visible())
+        if (!button->is_popup_visible())
         {
-            button->set_active(true);
+            button->popup();
         }
 
-        if (popover->get_child() != quick_target.get())
+        if (button->get_popover_child() != quick_target.get())
         {
-            popover->set_child(*quick_target);
+            button->set_popover_child(*quick_target);
             popover_timeout.disconnect();
         }
     };
@@ -137,13 +137,13 @@ void WayfireWpMixer::reload_config()
         {
             // unschedule hiding
             cancel_popover_timeout();
-            if (popover->get_child() != (Gtk::Widget*)&master_box)
+            if (button->get_popover_child() != (Gtk::Widget*)&master_box)
             {
-                popover->set_child(master_box);
+                button->set_popover_child(master_box);
                 // popdown so that when the click is processed, the popover is down, and thus pops up
                 // not the prettiest result, as it visibly closes instead of just replacing, but i’m not sure
                 // how to make it better
-                button->set_active(false);
+                button->popdown();
             }
         });
     }
@@ -160,11 +160,11 @@ void WayfireWpMixer::reload_config()
                 return;
             }
 
-            if (popover->get_child() != quick_target.get())
+            if (button->get_popover_child() != quick_target.get())
             {
-                popover->set_child(*quick_target);
+                button->set_popover_child(*quick_target);
                 // same as above
-                button->set_active(false);
+                button->popdown();
             }
         });
     }
@@ -219,12 +219,9 @@ void WayfireWpMixer::init(Gtk::Box *container)
 {
     // sets up the "widget part"
 
-    button = std::make_unique<WayfireMenuButton>("panel");
+    button = std::make_unique<WayfireMenuButton>("panel", "wp-mixer", "wp_mixer");
     button->add_css_class("widget-icon");
-    button->add_css_class("wp-mixer");
-    button->add_css_class("flat");
-    button->get_children()[0]->add_css_class("flat");
-    button->set_child(main_image);
+    button->append(main_image);
     button->show();
     sinks_box.add_css_class("outputs");
     sources_box.add_css_class("inputs");
@@ -232,10 +229,7 @@ void WayfireWpMixer::init(Gtk::Box *container)
     out_in_wall.add_css_class("out-in");
     in_streams_wall.add_css_class("in-streams");
 
-    popover = button->get_popover();
-    popover->set_child(master_box);
-    popover->set_autohide(false);
-    popover->add_css_class("wp-mixer-popover");
+    button->set_popover_child(master_box);
 
     // scroll to change volume of the object targetted by the quick_target widget
     auto scroll_gesture = Gtk::EventControllerScroll::create();
@@ -318,7 +312,6 @@ void WayfireWpMixer::init(Gtk::Box *container)
 
     // add to the actual container
     container->append(*button);
-    button->set_child(main_image);
 
     // if there is no audio device nor application, the quick target will not be set
     // and the widget will apear empty. Calling this here to always have the OOR icon.
@@ -357,7 +350,6 @@ void WayfireWpMixer::set_quick_target_from(WfWpControl *from)
 WayfireWpMixer::~WayfireWpMixer()
 {
     WpCommon::get().rem_widget(this);
-    gtk_widget_unparent(GTK_WIDGET(popover->gobj()));
     popover_timeout.disconnect();
     volume_changed_signal.disconnect();
     left_conn.disconnect();

--- a/src/panel/widgets/wp-mixer/wp-mixer.hpp
+++ b/src/panel/widgets/wp-mixer/wp-mixer.hpp
@@ -55,7 +55,6 @@ class WayfireWpMixer : public WayfireWidget
     WfOption<bool> popup_on_change{"panel/wp_popup_on_change"};
 
     std::unique_ptr<WayfireMenuButton> button;
-    Gtk::Popover *popover;
 
     /*
      * the "quick_target" is the representation of the audio channel that shows it’s volume

--- a/src/panel/widgets/wp-mixer/wp-mixer.hpp
+++ b/src/panel/widgets/wp-mixer/wp-mixer.hpp
@@ -54,7 +54,7 @@ class WayfireWpMixer : public WayfireWidget
     WfOption<bool> invert_scroll{"panel/wp_invert_scroll"};
     WfOption<bool> popup_on_change{"panel/wp_popup_on_change"};
 
-    std::unique_ptr<WayfireMenuButton> button;
+    std::unique_ptr<WayfireMenuWidget> button;
 
     /*
      * the "quick_target" is the representation of the audio channel that shows it’s volume

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -416,19 +416,21 @@ bool WayfireAutohidingWindow::update_margin()
     return false;
 }
 
+bool WayfireAutohidingWindow::is_active_popover(WayfireMenuWidget& button)
+{
+    return this->active_button == &button;
+}
+
+bool WayfireAutohidingWindow::has_active_popover()
+{
+    return this->active_button != nullptr;
+}
+
 void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
 {
-    if (&button != this->active_button)
+    if (!is_active_popover(button))
     {
-        if (this->active_button)
-        {
-            this->popover_hide.disconnect();
-        }
-
         this->active_button = &button;
-        this->popover_hide  =
-            this->active_button->signal_popdown().connect(
-                [this, &button] () { unset_active_popover(button); });
     }
 
     /* Set this panel to forcibly show over fullscreen apps */
@@ -438,39 +440,21 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
     }
 
     const bool should_grab_focus = this->active_button->is_keyboard_interactive();
-
-    /*
-     *  if (should_grab_focus)
-     *  {
-     *   // First, set exclusive mode to grab input
-     *   gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
-     *   wl_surface_commit(get_wl_surface());
-     *
-     *   // Next, allow releasing of focus when clicking outside of the panel
-     *   gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
-     *  }
-     */
-    // TODO come back for intentional focus steal
-
-    this->active_button->set_has_focus(should_grab_focus);
-    schedule_show(0);
-}
-
-void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
-{
-    if (!this->active_button || (&button != this->active_button))
+    if (should_grab_focus)
     {
-        return;
+        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+    } else
+    {
+        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
     }
 
-    unset_active_popover();
+    schedule_show(0);
 }
 
 void WayfireAutohidingWindow::unset_active_popover()
 {
     if (this->active_button)
     {
-        this->active_button->set_has_focus(false);
         this->active_button = nullptr;
         this->popover_hide.disconnect();
     }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -1,5 +1,6 @@
 #include "wf-autohide-window.hpp"
 #include "wayfire-shell-unstable-v2-client-protocol.h"
+#include "wf-popover.hpp"
 
 #include <gtk4-layer-shell.h>
 #include <wf-shell-app.hpp>
@@ -421,13 +422,11 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
         if (this->active_button)
         {
             this->popover_hide.disconnect();
-            this->active_button->set_active(false);
-            this->active_button->get_popover()->popdown();
         }
 
         this->active_button = &button;
         this->popover_hide  =
-            this->active_button->m_popover.signal_hide().connect(
+            this->active_button->signal_popdown().connect(
                 [this, &button] () { unset_active_popover(button); });
     }
 
@@ -458,7 +457,6 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     }
 
     this->active_button->set_has_focus(false);
-    this->active_button->set_active(false);
     this->active_button = nullptr;
     this->popover_hide.disconnect();
 
@@ -468,6 +466,11 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     {
         schedule_hide(AUTOHIDE_HIDE_DELAY);
     }
+}
+
+WayfireMenuButton*WayfireAutohidingWindow::get_active_popover()
+{
+    return this->active_button;
 }
 
 void WayfireAutohidingWindow::setup_autohide()

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -415,7 +415,7 @@ bool WayfireAutohidingWindow::update_margin()
     return false;
 }
 
-void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
+void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
 {
     if (&button != this->active_button)
     {
@@ -449,7 +449,7 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
     schedule_show(0);
 }
 
-void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
+void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
 {
     if (!this->active_button || (&button != this->active_button))
     {
@@ -468,7 +468,24 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     }
 }
 
-WayfireMenuButton*WayfireAutohidingWindow::get_active_popover()
+void WayfireAutohidingWindow::unset_active_popover()
+{
+    if (this->active_button)
+    {
+        this->active_button->set_has_focus(false);
+        this->active_button = nullptr;
+        this->popover_hide.disconnect();
+    }
+
+    gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
+
+    if (should_autohide())
+    {
+        schedule_hide(AUTOHIDE_HIDE_DELAY);
+    }
+}
+
+WayfireMenuWidget*WayfireAutohidingWindow::get_active_popover()
 {
     return this->active_button;
 }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -16,6 +16,7 @@
 
 WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     const std::string& section) :
+    force_show_popup{"panel/force_show_popup"},
     position{section + "/position"},
     y_position{WfOption<int>{section + "/autohide_duration"}},
     edge_offset{section + "/edge_offset"},
@@ -430,6 +431,12 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
                 [this, &button] () { unset_active_popover(button); });
     }
 
+    /* Set this panel to forcibly show over fullscreen apps */
+    if (force_show_popup.value())
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    }
+
     const bool should_grab_focus = this->active_button->is_keyboard_interactive();
 
     /*
@@ -456,16 +463,7 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
         return;
     }
 
-    this->active_button->set_has_focus(false);
-    this->active_button = nullptr;
-    this->popover_hide.disconnect();
-
-    gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
-
-    if (should_autohide())
-    {
-        schedule_hide(AUTOHIDE_HIDE_DELAY);
-    }
+    unset_active_popover();
 }
 
 void WayfireAutohidingWindow::unset_active_popover()
@@ -482,6 +480,28 @@ void WayfireAutohidingWindow::unset_active_popover()
     if (should_autohide())
     {
         schedule_hide(AUTOHIDE_HIDE_DELAY);
+    }
+
+    WfOption<std::string> panel_layer{"panel/layer"};
+
+    if ((std::string)panel_layer == "overlay")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    }
+
+    if ((std::string)panel_layer == "top")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_TOP);
+    }
+
+    if ((std::string)panel_layer == "bottom")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
+    }
+
+    if ((std::string)panel_layer == "background")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
     }
 }
 

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -33,6 +33,7 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     gtk_layer_init_for_window(this->gobj());
     gtk_layer_set_monitor(this->gobj(), output->monitor->gobj());
     gtk_layer_set_namespace(this->gobj(), "panel");
+    gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
 
 
     this->position.set_callback([=] () { this->update_position(); });

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -13,6 +13,7 @@
 
 WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     const std::string& section) :
+    force_show_popup{"panel/force_show_popup"},
     position{section + "/position"},
     full_span{section + "/full_span"},
     minimal_width{section + "/minimal_width"},
@@ -612,6 +613,12 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
                 [this, &button] () { unset_active_popover(button); });
     }
 
+    /* Set this panel to forcibly show over fullscreen apps */
+    if (force_show_popup.value())
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    }
+
     const bool should_grab_focus = this->active_button->is_keyboard_interactive();
 
     if (should_grab_focus)
@@ -635,16 +642,7 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
         return;
     }
 
-    this->active_button->set_has_focus(false);
-    this->active_button = nullptr;
-    this->popover_hide.disconnect();
-
-    gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
-
-    if (should_autohide())
-    {
-        schedule_hide(autohide_hide_delay);
-    }
+    unset_active_popover();
 }
 
 void WayfireAutohidingWindow::unset_active_popover()
@@ -661,6 +659,28 @@ void WayfireAutohidingWindow::unset_active_popover()
     if (should_autohide())
     {
         schedule_hide(autohide_hide_delay);
+    }
+
+    WfOption<std::string> panel_layer{"panel/layer"};
+
+    if ((std::string)panel_layer == "overlay")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    }
+
+    if ((std::string)panel_layer == "top")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_TOP);
+    }
+
+    if ((std::string)panel_layer == "bottom")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
+    }
+
+    if ((std::string)panel_layer == "background")
+    {
+        gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
     }
 }
 

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -617,7 +617,7 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
     }
 
     /* Set this panel to forcibly show over fullscreen apps */
-    if (force_show_popup.value())
+    if (button.is_manual_popup() && force_show_popup.value())
     {
         gtk_layer_set_layer(gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
     }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -625,7 +625,7 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
     const bool should_grab_focus = this->active_button->is_keyboard_interactive();
     if (should_grab_focus)
     {
-        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
     } else
     {
         gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -1,5 +1,6 @@
 #include "wf-autohide-window.hpp"
 #include "wayfire-shell-unstable-v2-client-protocol.h"
+#include "wf-popover.hpp"
 
 #include <gtk4-layer-shell.h>
 #include <wf-shell-app.hpp>
@@ -603,13 +604,11 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
         if (this->active_button)
         {
             this->popover_hide.disconnect();
-            this->active_button->set_active(false);
-            this->active_button->get_popover()->popdown();
         }
 
         this->active_button = &button;
         this->popover_hide  =
-            this->active_button->m_popover.signal_hide().connect(
+            this->active_button->signal_popdown().connect(
                 [this, &button] () { unset_active_popover(button); });
     }
 
@@ -637,7 +636,6 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     }
 
     this->active_button->set_has_focus(false);
-    this->active_button->set_active(false);
     this->active_button = nullptr;
     this->popover_hide.disconnect();
 
@@ -647,6 +645,11 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     {
         schedule_hide(autohide_hide_delay);
     }
+}
+
+WayfireMenuButton*WayfireAutohidingWindow::get_active_popover()
+{
+    return this->active_button;
 }
 
 void WayfireAutohidingWindow::setup_autohide()

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -597,7 +597,7 @@ bool WayfireAutohidingWindow::update_margin()
     return false;
 }
 
-void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
+void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
 {
     if (&button != this->active_button)
     {
@@ -628,7 +628,7 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuButton& button)
     schedule_show(0);
 }
 
-void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
+void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
 {
     if (!this->active_button || (&button != this->active_button))
     {
@@ -647,7 +647,24 @@ void WayfireAutohidingWindow::unset_active_popover(WayfireMenuButton& button)
     }
 }
 
-WayfireMenuButton*WayfireAutohidingWindow::get_active_popover()
+void WayfireAutohidingWindow::unset_active_popover()
+{
+    if (this->active_button)
+    {
+        this->active_button->set_has_focus(false);
+        this->active_button = nullptr;
+        this->popover_hide.disconnect();
+    }
+
+    gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
+
+    if (should_autohide())
+    {
+        schedule_hide(autohide_hide_delay);
+    }
+}
+
+WayfireMenuWidget*WayfireAutohidingWindow::get_active_popover()
 {
     return this->active_button;
 }

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -598,19 +598,21 @@ bool WayfireAutohidingWindow::update_margin()
     return false;
 }
 
+bool WayfireAutohidingWindow::is_active_popover(WayfireMenuWidget& button)
+{
+    return this->active_button == &button;
+}
+
+bool WayfireAutohidingWindow::has_active_popover()
+{
+    return this->active_button != nullptr;
+}
+
 void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
 {
-    if (&button != this->active_button)
+    if (!is_active_popover(button))
     {
-        if (this->active_button)
-        {
-            this->popover_hide.disconnect();
-        }
-
         this->active_button = &button;
-        this->popover_hide  =
-            this->active_button->signal_popdown().connect(
-                [this, &button] () { unset_active_popover(button); });
     }
 
     /* Set this panel to forcibly show over fullscreen apps */
@@ -620,36 +622,21 @@ void WayfireAutohidingWindow::set_active_popover(WayfireMenuWidget& button)
     }
 
     const bool should_grab_focus = this->active_button->is_keyboard_interactive();
-
     if (should_grab_focus)
     {
-        // First, set exclusive mode to grab input
-        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
-        wl_surface_commit(get_wl_surface());
-
-        // Next, allow releasing of focus when clicking outside of the panel
         gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
-    }
-
-    this->active_button->set_has_focus(should_grab_focus);
-    schedule_show(0);
-}
-
-void WayfireAutohidingWindow::unset_active_popover(WayfireMenuWidget& button)
-{
-    if (!this->active_button || (&button != this->active_button))
+    } else
     {
-        return;
+        gtk_layer_set_keyboard_mode(this->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
     }
 
-    unset_active_popover();
+    schedule_show(0);
 }
 
 void WayfireAutohidingWindow::unset_active_popover()
 {
     if (this->active_button)
     {
-        this->active_button->set_has_focus(false);
         this->active_button = nullptr;
         this->popover_hide.disconnect();
     }

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -60,30 +60,20 @@ class WayfireAutohidingWindow : public Gtk::Window
      * Note that autohide margin isn't taken into account. */
     void set_auto_exclusive_zone(bool has_zone = false);
 
-    /**
-     * Set the currently active popover button.
-     * The lastly activated popover, if any, will be closed, in order to
-     * show this new one.
-     *
-     * In addition, if the window has an active popover, it will grab the
-     * keyboard input and deactivate the popover when the focus is lost.
-     */
     void set_active_popover(WayfireMenuWidget& button);
-
-    /**
-     * No-op if the given popover is not the currently active popover.
-     *
-     * Unsets the currently active popover and reverses the effects of setting
-     * making it active with set_active_popover()
-     */
-    void unset_active_popover(WayfireMenuWidget& popover);
-
+    bool is_active_popover(WayfireMenuWidget& button);
+    bool has_active_popover();
     void unset_active_popover();
 
     /*
      * Get Active popover or null
      */
     WayfireMenuWidget *get_active_popover();
+
+    WayfireOutput *get_output()
+    {
+        return output;
+    }
 
   private:
     WayfireOutput *output;

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -46,6 +46,8 @@ class WayfireAutohidingWindow : public Gtk::Window
     WayfireAutohidingWindow& operator =(const WayfireAutohidingWindow&) = delete;
     WayfireAutohidingWindow& operator =(WayfireAutohidingWindow&&) = delete;
 
+    WfOption<bool> force_show_popup;
+
     ~WayfireAutohidingWindow();
     wl_surface *get_wl_surface() const;
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -66,7 +66,7 @@ class WayfireAutohidingWindow : public Gtk::Window
      * In addition, if the window has an active popover, it will grab the
      * keyboard input and deactivate the popover when the focus is lost.
      */
-    void set_active_popover(WayfireMenuButton& button);
+    void set_active_popover(WayfireMenuWidget& button);
 
     /**
      * No-op if the given popover is not the currently active popover.
@@ -74,12 +74,14 @@ class WayfireAutohidingWindow : public Gtk::Window
      * Unsets the currently active popover and reverses the effects of setting
      * making it active with set_active_popover()
      */
-    void unset_active_popover(WayfireMenuButton& popover);
+    void unset_active_popover(WayfireMenuWidget& popover);
+
+    void unset_active_popover();
 
     /*
      * Get Active popover or null
      */
-    WayfireMenuButton *get_active_popover();
+    WayfireMenuWidget *get_active_popover();
 
   private:
     WayfireOutput *output;
@@ -125,7 +127,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     void setup_hotspot();
 
     sigc::connection popover_hide;
-    WayfireMenuButton *active_button = nullptr;
+    WayfireMenuWidget *active_button = nullptr;
 };
 
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -85,6 +85,11 @@ class WayfireAutohidingWindow : public Gtk::Window
      */
     void unset_active_popover(WayfireMenuButton& popover);
 
+    /*
+     * Get Active popover or null
+     */
+    WayfireMenuButton *get_active_popover();
+
   private:
     WayfireOutput *output;
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -75,7 +75,7 @@ class WayfireAutohidingWindow : public Gtk::Window
      * In addition, if the window has an active popover, it will grab the
      * keyboard input and deactivate the popover when the focus is lost.
      */
-    void set_active_popover(WayfireMenuButton& button);
+    void set_active_popover(WayfireMenuWidget& button);
 
     /**
      * No-op if the given popover is not the currently active popover.
@@ -83,12 +83,14 @@ class WayfireAutohidingWindow : public Gtk::Window
      * Unsets the currently active popover and reverses the effects of setting
      * making it active with set_active_popover()
      */
-    void unset_active_popover(WayfireMenuButton& popover);
+    void unset_active_popover(WayfireMenuWidget& popover);
+
+    void unset_active_popover();
 
     /*
      * Get Active popover or null
      */
-    WayfireMenuButton *get_active_popover();
+    WayfireMenuWidget *get_active_popover();
 
   private:
     WayfireOutput *output;
@@ -145,7 +147,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     void setup_hotspot();
 
     sigc::connection popover_hide;
-    WayfireMenuButton *active_button = nullptr;
+    WayfireMenuWidget *active_button = nullptr;
 };
 
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -69,30 +69,20 @@ class WayfireAutohidingWindow : public Gtk::Window
      * Note that autohide margin isn't taken into account. */
     void set_auto_exclusive_zone(bool has_zone = false);
 
-    /**
-     * Set the currently active popover button.
-     * The lastly activated popover, if any, will be closed, in order to
-     * show this new one.
-     *
-     * In addition, if the window has an active popover, it will grab the
-     * keyboard input and deactivate the popover when the focus is lost.
-     */
     void set_active_popover(WayfireMenuWidget& button);
-
-    /**
-     * No-op if the given popover is not the currently active popover.
-     *
-     * Unsets the currently active popover and reverses the effects of setting
-     * making it active with set_active_popover()
-     */
-    void unset_active_popover(WayfireMenuWidget& popover);
-
+    bool is_active_popover(WayfireMenuWidget& button);
+    bool has_active_popover();
     void unset_active_popover();
 
     /*
      * Get Active popover or null
      */
     WayfireMenuWidget *get_active_popover();
+
+    WayfireOutput *get_output()
+    {
+        return output;
+    }
 
   private:
     WayfireOutput *output;

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -76,6 +76,11 @@ class WayfireAutohidingWindow : public Gtk::Window
      */
     void unset_active_popover(WayfireMenuButton& popover);
 
+    /*
+     * Get Active popover or null
+     */
+    WayfireMenuButton *get_active_popover();
+
   private:
     WayfireOutput *output;
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -37,6 +37,8 @@ class WayfireAutohidingWindow : public Gtk::Window
     WayfireAutohidingWindow& operator =(const WayfireAutohidingWindow&) = delete;
     WayfireAutohidingWindow& operator =(WayfireAutohidingWindow&&) = delete;
 
+    WfOption<bool> force_show_popup;
+
     ~WayfireAutohidingWindow();
     wl_surface *get_wl_surface() const;
 

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -85,7 +85,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     }
 
   private:
-    WayfireOutput *output;
+    WayfireOutput *output = nullptr;
 
     std::vector<sigc::connection> signals;
 

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,10 +1,8 @@
 #include "wf-popover.hpp"
-#include "giomm/menu.h"
 #include "giomm/menumodel.h"
 #include "glibmm/refptr.h"
 #include "gtk/gtk.h"
 #include "gtkmm/eventcontrollermotion.h"
-#include "gtkmm/gesture.h"
 #include "gtkmm/gestureclick.h"
 #include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
@@ -51,7 +49,11 @@ void WayfirePopup::set_child(Gtk::Widget & widget)
 {
     menu.popdown();
     use_menu = false;
-    popover.set_child(widget);
+    popover.set_child(scroll);
+    scroll.set_child(widget);
+    scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);
+    scroll.set_propagate_natural_height(true);
+    scroll.set_propagate_natural_width(true);
 }
 
 void WayfirePopup::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,13 +1,17 @@
 #include "wf-popover.hpp"
 #include "giomm/menumodel.h"
-#include "glibmm/refptr.h"
+#include "glib.h"
+#include "glibmm.h"
+#include "glibmm/main.h"
 #include "gtk/gtk.h"
 #include "gtkmm/eventcontrollermotion.h"
 #include "gtkmm/gestureclick.h"
 #include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
 #include <cstddef>
+#include <iostream>
 #include <memory>
+#include <gtk4-layer-shell.h>
 
 /* Helper to get panel from button. NULL if not added to one */
 WayfireAutohidingWindow *get_panel(Gtk::Widget *button)
@@ -22,90 +26,115 @@ WayfireAutohidingWindow *get_panel(Gtk::Widget *button)
     return autohide_window;
 }
 
-WayfirePopup::WayfirePopup(std::string class_name, std::string option_name)
+void WayfireMenuWidget::set_no_child()
 {
-    popover.add_css_class(class_name + "-popover");
-
-    signals.push_back(popover.signal_closed().connect([=] ()
-    {
-        popdown();
-    }));
-
-    signals.push_back(menu.signal_closed().connect([=] ()
-    {
-        popdown();
-    }));
-}
-
-WayfirePopup::~WayfirePopup()
-{
-    for (auto signal : signals)
-    {
-        signal.disconnect();
-    }
-}
-
-void WayfirePopup::set_child(Gtk::Widget & widget)
-{
-    menu.popdown();
-    use_menu = false;
-    popover.set_child(scroll);
-    scroll.set_child(widget);
-    scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);
-    scroll.set_propagate_natural_height(true);
-    scroll.set_propagate_natural_width(true);
-}
-
-void WayfirePopup::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)
-{
+    remove_css_class("with-content");
     popover.popdown();
-    use_menu = true;
+    menu.popdown();
+    use_menu   = false;
+    use_widget = false;
+}
+
+void WayfireMenuWidget::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)
+{
+    add_css_class("with-content");
+    popover.popdown();
+    use_menu   = true;
+    use_widget = false;
     menu.set_menu_model(new_menu);
 }
 
-Gtk::Widget*WayfirePopup::get_child()
+void WayfireMenuWidget::popup()
 {
-    return popover.get_child();
-}
+    cancel_timer();
+    auto panel = get_panel(this);
+    if (!panel)
+    {
+        return;
+    }
 
-void WayfirePopup::set_parent(Gtk::Widget & parent)
-{
-    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(parent.gobj()));
-    gtk_widget_set_parent(GTK_WIDGET(menu.gobj()), GTK_WIDGET(parent.gobj()));
-}
+    if (panel->is_active_popover(*this))
+    {
+        return;
+    }
 
-void WayfirePopup::unset_parent()
-{
-    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
-    gtk_widget_unparent(GTK_WIDGET(menu.gobj()));
-}
-
-void WayfirePopup::popup()
-{
     if (use_menu)
     {
         menu.popup();
+    } else if (use_widget)
+    {
+        if (fullscreen)
+        {
+            fullscreen->show();
+        } else
+        {
+            popover.popup();
+        }
     } else
     {
-        popover.popup();
+        return;
     }
+
+    add_css_class("selected");
+
+    panel->set_active_popover(*this);
+    popup_signal.emit();
 }
 
-void WayfirePopup::popdown()
+void WayfireMenuWidget::popup_timed(int millis)
 {
-    if (use_menu)
+    /* Timed popup is assumed to not be a user action. Do not popup if a popup is already shown */
+    auto panel = get_panel(this);
+    if (!panel)
     {
-        menu.popdown();
-    } else
-    {
-        popover.popdown();
+        return;
     }
 
-    auto panel = get_panel(&popover);
-    if (panel)
+    if (panel->is_active_popover(*this))
     {
-        panel->unset_active_popover();
+        /* If it is us and we've got a timer, reset timer */
+
+        if (timer_signal.connected())
+        {
+            set_timer(millis);
+        }
+
+        return;
     }
+
+    if (panel->has_active_popover())
+    {
+        return;
+    }
+
+    popup();
+    set_timer(millis);
+}
+
+void WayfireMenuWidget::popdown()
+{
+    cancel_timer();
+    auto panel = get_panel(this);
+    if (!panel)
+    {
+        return;
+    }
+
+    remove_css_class("selected");
+    menu.popdown();
+    popover.popdown();
+    if (fullscreen)
+    {
+        fullscreen->hide();
+    }
+
+    if (!use_menu && !use_widget)
+    {
+        return;
+    }
+
+    popdown_signal.emit();
+    panel->unset_active_popover();
 }
 
 void WayfireMenuWidget::open_on(int button)
@@ -133,15 +162,26 @@ void WayfireMenuWidget::open_on(int button)
 
 WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::string class_name,
     const std::string option_name) :
-    panel_position{section + "/position"}
+    panel_position{section + "/position"}, class_name(class_name)
 {
+    /* WayfireMenuWidget gets class name directly */
     add_css_class(class_name);
+    add_css_class("wf-menu");
+    /* Add generic popover class to both */
+    popover.add_css_class("popover");
+    menu.add_css_class("popover");
+    /* Add specific popover class to both */
+    popover.add_css_class(class_name + "-popover");
+    menu.add_css_class(class_name + "-popover");
 
-    m_popup = std::make_shared<WayfirePopup>(class_name, option_name);
-    m_popup->set_parent(*this);
+    /* Scroller around widget popover for small screens */
+    popover.set_child(scroll);
+    scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);
+    scroll.set_propagate_natural_height(true);
+    scroll.set_propagate_natural_width(true);
 
-
-
+    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(this->gobj()));
+    gtk_widget_set_parent(GTK_WIDGET(menu.gobj()), GTK_WIDGET(this->gobj()));
     /* Moved to another menu */
     auto motion_gesture = Gtk::EventControllerMotion::create();
     signals.push_back(motion_gesture->signal_enter().connect(
@@ -155,17 +195,37 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
         auto panel = get_panel(this);
         if (panel)
         {
-            auto current = panel->get_active_popover();
-            if ((current != nullptr) && (current != this))
+            /* Without contents, don't switch */
+            if (!use_menu && !use_widget)
             {
+                return;
+            }
+
+            if (panel->has_active_popover() && !panel->is_active_popover(*this))
+            {
+                if (panel->get_active_popover()->timer_signal.connected())
+                {
+                    return;
+                }
+
                 panel->get_active_popover()->popdown();
                 popup();
             }
         }
     }));
     add_controller(motion_gesture);
+    signals.push_back(popover.signal_closed().connect([=] ()
+    {
+        popdown();
+    }));
+
+    signals.push_back(menu.signal_closed().connect([=] ()
+    {
+        popdown();
+    }));
 }
 
+/* Most cases use class and option named the same. But not all */
 WayfireMenuWidget::WayfireMenuWidget(const std::string& section, std::string name) :
     WayfireMenuWidget(section, name, name)
 {}
@@ -177,8 +237,11 @@ WayfireMenuWidget::~WayfireMenuWidget()
         signal.disconnect();
     }
 
+    timer_signal.disconnect();
     click_signal.disconnect();
-    m_popup->unset_parent();
+
+    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
+    gtk_widget_unparent(GTK_WIDGET(menu.gobj()));
 }
 
 void WayfireMenuWidget::set_keyboard_interactive(bool interactive)
@@ -191,16 +254,6 @@ bool WayfireMenuWidget::is_keyboard_interactive() const
     return this->interactive;
 }
 
-void WayfireMenuWidget::set_has_focus(bool focus)
-{
-    this->has_focus = focus;
-}
-
-bool WayfireMenuWidget::is_popup_focused() const
-{
-    return this->has_focus;
-}
-
 void WayfireMenuWidget::set_active_on_window()
 {
     auto panel = get_panel(this);
@@ -210,57 +263,39 @@ void WayfireMenuWidget::set_active_on_window()
     }
 }
 
-void WayfireMenuWidget::grab_focus()
-{
-    set_keyboard_interactive();
-    set_active_on_window(); // actually grab focus
-}
-
 void WayfireMenuWidget::set_popup_child(Gtk::Widget & widget)
 {
-    m_popup->set_child(widget);
+    add_css_class("with-content");
+    menu.popdown();
+    use_menu   = false;
+    use_widget = true;
+    scroll.set_child(widget);
 }
 
 Gtk::Widget*WayfireMenuWidget::get_popup_child()
 {
-    return m_popup->get_child();
-}
-
-void WayfireMenuWidget::popup()
-{
-    m_popup->popup();
-    popup_signal.emit();
-    auto panel = get_panel(this);
-    if (panel)
-    {
-        panel->set_active_popover(*this);
-    }
-}
-
-void WayfireMenuWidget::popdown()
-{
-    m_popup->popdown();
-    popdown_signal.emit();
-    auto panel = get_panel(this);
-    if (panel)
-    {
-        panel->unset_active_popover(*this);
-    }
+    return popover.get_child();
 }
 
 void WayfireMenuWidget::toggle()
 {
-    auto panel = get_panel(this);
-    if (panel)
+    Glib::signal_idle().connect([=] ()
     {
-        if (panel->get_active_popover() == NULL)
+        auto panel = get_panel(this);
+        if (panel)
         {
-            popup();
-        } else
-        {
-            popdown();
+            WayfireMenuWidget *popover = panel->get_active_popover();
+            if (popover == NULL)
+            {
+                popup();
+            } else
+            {
+                popover->popdown();
+            }
         }
-    }
+
+        return G_SOURCE_REMOVE;
+    });
 }
 
 bool WayfireMenuWidget::is_popup_visible()
@@ -274,7 +309,54 @@ bool WayfireMenuWidget::is_popup_visible()
     return false;
 }
 
-void WayfireMenuWidget::set_menu_model(Glib::RefPtr<Gio::MenuModel> menu)
+void WayfireMenuWidget::set_fullscreen(bool fs)
 {
-    m_popup->set_menu_model(menu);
+    auto panel = get_panel(this);
+    if (!panel)
+    {
+        return;
+    }
+
+    if (fs && (fullscreen == nullptr))
+    {
+        gtk_popover_set_child(popover.gobj(), nullptr);
+
+        /* Prepare fullscreen layer */
+        fullscreen = std::make_shared<Gtk::Window>();
+        fullscreen->add_css_class(class_name + "-fullscreen-popover");
+        fullscreen->add_css_class(class_name + "-popover");
+        fullscreen->add_css_class("fullscreen-popover");
+        gtk_layer_init_for_window(fullscreen->gobj());
+        gtk_layer_set_namespace(fullscreen->gobj(), "panelmenu");
+        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_TOP, true);
+        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, true);
+        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_LEFT, true);
+        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, true);
+        gtk_layer_set_layer(fullscreen->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
+        gtk_layer_set_keyboard_mode(fullscreen->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
+        gtk_layer_set_monitor(fullscreen->gobj(), panel->get_output()->monitor->gobj());
+
+        fullscreen->set_child(scroll);
+    } else if (!fs && fullscreen)
+    {
+        gtk_window_set_child(fullscreen->gobj(), nullptr);
+        popover.set_child(scroll);
+        fullscreen->close();
+        fullscreen = nullptr;
+    }
+}
+
+void WayfireMenuWidget::cancel_timer()
+{
+    timer_signal.disconnect();
+}
+
+void WayfireMenuWidget::set_timer(int millis)
+{
+    timer_signal.disconnect();
+    timer_signal = Glib::signal_timeout().connect([=]
+    {
+        popdown();
+        return G_SOURCE_REMOVE;
+    }, millis);
 }

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -26,6 +26,11 @@ WayfireAutohidingWindow *get_panel(Gtk::Widget *button)
     return autohide_window;
 }
 
+void WayfireMenuWidget::set_child(Gtk::Widget & widget)
+{
+    append(widget);
+}
+
 void WayfireMenuWidget::set_no_child()
 {
     remove_css_class("with-content");

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -147,6 +147,11 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     signals.push_back(motion_gesture->signal_enter().connect(
         [=] (double, double)
     {
+        if (!menus_motion.value())
+        {
+            return;
+        }
+
         auto panel = get_panel(this);
         if (panel)
         {

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,4 +1,8 @@
 #include "wf-popover.hpp"
+#include "giomm/menu.h"
+#include "giomm/menumodel.h"
+#include "glibmm/refptr.h"
+#include "gtk/gtk.h"
 #include "gtkmm/eventcontrollermotion.h"
 #include "gtkmm/gesture.h"
 #include "gtkmm/gestureclick.h"
@@ -8,7 +12,7 @@
 #include <memory>
 
 /* Helper to get panel from button. NULL if not added to one */
-WayfireAutohidingWindow *get_panel(WayfireMenuButton *button)
+WayfireAutohidingWindow *get_panel(Gtk::Widget *button)
 {
     auto window = button->get_root();
     if (!window)
@@ -20,64 +24,121 @@ WayfireAutohidingWindow *get_panel(WayfireMenuButton *button)
     return autohide_window;
 }
 
-WayfirePopover::WayfirePopover(std::string class_name, std::string option_name)
+WayfirePopup::WayfirePopup(std::string class_name, std::string option_name)
 {
     popover.add_css_class(class_name + "-popover");
+
+    signals.push_back(popover.signal_closed().connect([=] ()
+    {
+        popdown();
+    }));
+
+    signals.push_back(menu.signal_closed().connect([=] ()
+    {
+        popdown();
+    }));
 }
 
-void WayfirePopover::set_child(Gtk::Widget & widget)
+WayfirePopup::~WayfirePopup()
 {
+    for (auto signal : signals)
+    {
+        signal.disconnect();
+    }
+}
+
+void WayfirePopup::set_child(Gtk::Widget & widget)
+{
+    menu.popdown();
+    use_menu = false;
     popover.set_child(widget);
 }
 
-Gtk::Widget*WayfirePopover::get_child()
+void WayfirePopup::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)
+{
+    popover.popdown();
+    use_menu = true;
+    menu.set_menu_model(new_menu);
+}
+
+Gtk::Widget*WayfirePopup::get_child()
 {
     return popover.get_child();
 }
 
-void WayfirePopover::set_parent(Gtk::Widget & parent)
+void WayfirePopup::set_parent(Gtk::Widget & parent)
 {
     gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(parent.gobj()));
+    gtk_widget_set_parent(GTK_WIDGET(menu.gobj()), GTK_WIDGET(parent.gobj()));
 }
 
-void WayfirePopover::unset_parent()
+void WayfirePopup::unset_parent()
 {
     gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
+    gtk_widget_unparent(GTK_WIDGET(menu.gobj()));
 }
 
-void WayfirePopover::popup()
+void WayfirePopup::popup()
 {
-    popover.popup();
+    if (use_menu)
+    {
+        menu.popup();
+    } else
+    {
+        popover.popup();
+    }
 }
 
-void WayfirePopover::popdown()
+void WayfirePopup::popdown()
 {
-    popover.popdown();
+    if (use_menu)
+    {
+        menu.popdown();
+    } else
+    {
+        popover.popdown();
+    }
+
+    auto panel = get_panel(&popover);
+    if (panel)
+    {
+        panel->unset_active_popover();
+    }
 }
 
-WayfireMenuButton::WayfireMenuButton(const std::string& section, const std::string class_name,
+void WayfireMenuWidget::open_on(int button)
+{
+    if (click_signal)
+    {
+        click_signal.disconnect();
+    }
+
+    if (button < 0)
+    {
+        return;
+    }
+
+    auto click_gesture = Gtk::GestureClick::create();
+    click_gesture->set_button(button);
+    /* Action on release */
+    click_signal = click_gesture->signal_released().connect(
+        [=] (int, double, double)
+    {
+        toggle();
+    });
+    add_controller(click_gesture);
+}
+
+WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::string class_name,
     const std::string option_name) :
     panel_position{section + "/position"}
 {
     add_css_class(class_name);
 
-    m_popover = std::make_shared<WayfirePopover>(class_name, option_name);
-    m_popover->set_parent(*this);
+    m_popup = std::make_shared<WayfirePopup>(class_name, option_name);
+    m_popup->set_parent(*this);
 
-    auto click_gesture = Gtk::GestureClick::create();
-    click_gesture->set_button(1);
-    /* Catch a press-start */
-    signals.push_back(click_gesture->signal_pressed().connect(
-        [=] (int btn, double x, double y)
-    {
-        click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
-    }));
-    /* Action on release */
-    signals.push_back(click_gesture->signal_released().connect(
-        [=] (int, double, double)
-    {
-        toggle();
-    }));
+
 
     /* Moved to another menu */
     auto motion_gesture = Gtk::EventControllerMotion::create();
@@ -95,47 +156,45 @@ WayfireMenuButton::WayfireMenuButton(const std::string& section, const std::stri
             }
         }
     }));
-
-
-    add_controller(click_gesture);
     add_controller(motion_gesture);
 }
 
-WayfireMenuButton::WayfireMenuButton(const std::string& section, std::string name) :
-    WayfireMenuButton(section, name, name)
+WayfireMenuWidget::WayfireMenuWidget(const std::string& section, std::string name) :
+    WayfireMenuWidget(section, name, name)
 {}
 
-WayfireMenuButton::~WayfireMenuButton()
+WayfireMenuWidget::~WayfireMenuWidget()
 {
     for (auto signal : signals)
     {
         signal.disconnect();
     }
 
-    m_popover->unset_parent();
+    click_signal.disconnect();
+    m_popup->unset_parent();
 }
 
-void WayfireMenuButton::set_keyboard_interactive(bool interactive)
+void WayfireMenuWidget::set_keyboard_interactive(bool interactive)
 {
     this->interactive = interactive;
 }
 
-bool WayfireMenuButton::is_keyboard_interactive() const
+bool WayfireMenuWidget::is_keyboard_interactive() const
 {
     return this->interactive;
 }
 
-void WayfireMenuButton::set_has_focus(bool focus)
+void WayfireMenuWidget::set_has_focus(bool focus)
 {
     this->has_focus = focus;
 }
 
-bool WayfireMenuButton::is_popover_focused() const
+bool WayfireMenuWidget::is_popup_focused() const
 {
     return this->has_focus;
 }
 
-void WayfireMenuButton::set_active_on_window()
+void WayfireMenuWidget::set_active_on_window()
 {
     auto panel = get_panel(this);
     if (panel)
@@ -144,25 +203,25 @@ void WayfireMenuButton::set_active_on_window()
     }
 }
 
-void WayfireMenuButton::grab_focus()
+void WayfireMenuWidget::grab_focus()
 {
     set_keyboard_interactive();
     set_active_on_window(); // actually grab focus
 }
 
-void WayfireMenuButton::set_popover_child(Gtk::Widget & widget)
+void WayfireMenuWidget::set_popup_child(Gtk::Widget & widget)
 {
-    m_popover->set_child(widget);
+    m_popup->set_child(widget);
 }
 
-Gtk::Widget*WayfireMenuButton::get_popover_child()
+Gtk::Widget*WayfireMenuWidget::get_popup_child()
 {
-    return m_popover->get_child();
+    return m_popup->get_child();
 }
 
-void WayfireMenuButton::popup()
+void WayfireMenuWidget::popup()
 {
-    m_popover->popup();
+    m_popup->popup();
     popup_signal.emit();
     auto panel = get_panel(this);
     if (panel)
@@ -171,13 +230,18 @@ void WayfireMenuButton::popup()
     }
 }
 
-void WayfireMenuButton::popdown()
+void WayfireMenuWidget::popdown()
 {
-    m_popover->popdown();
+    m_popup->popdown();
     popdown_signal.emit();
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        panel->unset_active_popover(*this);
+    }
 }
 
-void WayfireMenuButton::toggle()
+void WayfireMenuWidget::toggle()
 {
     auto panel = get_panel(this);
     if (panel)
@@ -192,7 +256,7 @@ void WayfireMenuButton::toggle()
     }
 }
 
-bool WayfireMenuButton::is_popup_visible()
+bool WayfireMenuWidget::is_popup_visible()
 {
     auto panel = get_panel(this);
     if (panel)
@@ -201,4 +265,9 @@ bool WayfireMenuButton::is_popup_visible()
     }
 
     return false;
+}
+
+void WayfireMenuWidget::set_menu_model(Glib::RefPtr<Gio::MenuModel> menu)
+{
+    m_popup->set_menu_model(menu);
 }

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,28 +1,118 @@
 #include "wf-popover.hpp"
+#include "gtkmm/eventcontrollermotion.h"
+#include "gtkmm/gesture.h"
+#include "gtkmm/gestureclick.h"
+#include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
+#include <cstddef>
+#include <memory>
 
-WayfireMenuButton::WayfireMenuButton(const std::string& section) :
+/* Helper to get panel from button. NULL if not added to one */
+WayfireAutohidingWindow *get_panel(WayfireMenuButton *button)
+{
+    auto window = button->get_root();
+    if (!window)
+    {
+        return NULL;
+    }
+
+    auto autohide_window = dynamic_cast<WayfireAutohidingWindow*>(window);
+    return autohide_window;
+}
+
+WayfirePopover::WayfirePopover(std::string class_name, std::string option_name)
+{
+    popover.add_css_class(class_name + "-popover");
+}
+
+void WayfirePopover::set_child(Gtk::Widget & widget)
+{
+    popover.set_child(widget);
+}
+
+Gtk::Widget*WayfirePopover::get_child()
+{
+    return popover.get_child();
+}
+
+void WayfirePopover::set_parent(Gtk::Widget & parent)
+{
+    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(parent.gobj()));
+}
+
+void WayfirePopover::unset_parent()
+{
+    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
+}
+
+void WayfirePopover::popup()
+{
+    popover.popup();
+}
+
+void WayfirePopover::popdown()
+{
+    popover.popdown();
+}
+
+WayfireMenuButton::WayfireMenuButton(const std::string& section, const std::string class_name,
+    const std::string option_name) :
     panel_position{section + "/position"}
 {
-    add_css_class("flat");
-    // m_popover.set_constrain_to(Gtk::POPOVER_CONSTRAINT_NONE);
+    add_css_class(class_name);
 
-    auto cb = [=] ()
+    m_popover = std::make_shared<WayfirePopover>(class_name, option_name);
+    m_popover->set_parent(*this);
+
+    auto click_gesture = Gtk::GestureClick::create();
+    click_gesture->set_button(1);
+    /* Catch a press-start */
+    signals.push_back(click_gesture->signal_pressed().connect(
+        [=] (int btn, double x, double y)
     {
-        // set_direction((std::string)panel_position == "top" ?
-        // Gtk::Arrow::DOWN : Gtk::Arrow::UP);
-
-        this->unset_popover();
-        // m_popover.set_constrain_to(Gtk::POPOVER_CONSTRAINT_NONE);
-        set_popover(m_popover);
-    };
-    panel_position.set_callback(cb);
-    cb();
-
-    m_popover.signal_show().connect([=]
+        click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
+    }));
+    /* Action on release */
+    signals.push_back(click_gesture->signal_released().connect(
+        [=] (int, double, double)
     {
-        set_active_on_window();
-    });
+        toggle();
+    }));
+
+    /* Moved to another menu */
+    auto motion_gesture = Gtk::EventControllerMotion::create();
+    signals.push_back(motion_gesture->signal_enter().connect(
+        [=] (double, double)
+    {
+        auto panel = get_panel(this);
+        if (panel)
+        {
+            auto current = panel->get_active_popover();
+            if ((current != nullptr) && (current != this))
+            {
+                panel->get_active_popover()->popdown();
+                popup();
+            }
+        }
+    }));
+
+
+    add_controller(click_gesture);
+    add_controller(motion_gesture);
+}
+
+WayfireMenuButton::WayfireMenuButton(const std::string& section, std::string name) :
+    WayfireMenuButton(section, name, name)
+{}
+
+WayfireMenuButton::~WayfireMenuButton()
+{
+    for (auto signal : signals)
+    {
+        signal.disconnect();
+    }
+
+    m_popover->unset_parent();
 }
 
 void WayfireMenuButton::set_keyboard_interactive(bool interactive)
@@ -47,16 +137,10 @@ bool WayfireMenuButton::is_popover_focused() const
 
 void WayfireMenuButton::set_active_on_window()
 {
-    auto window = this->get_parent();
-    while (window && window->get_parent())
+    auto panel = get_panel(this);
+    if (panel)
     {
-        window = window->get_parent();
-    }
-
-    auto autohide_window = dynamic_cast<WayfireAutohidingWindow*>(window);
-    if (autohide_window)
-    {
-        autohide_window->set_active_popover(*this);
+        panel->set_active_popover(*this);
     }
 }
 
@@ -64,4 +148,57 @@ void WayfireMenuButton::grab_focus()
 {
     set_keyboard_interactive();
     set_active_on_window(); // actually grab focus
+}
+
+void WayfireMenuButton::set_popover_child(Gtk::Widget & widget)
+{
+    m_popover->set_child(widget);
+}
+
+Gtk::Widget*WayfireMenuButton::get_popover_child()
+{
+    return m_popover->get_child();
+}
+
+void WayfireMenuButton::popup()
+{
+    m_popover->popup();
+    popup_signal.emit();
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        panel->set_active_popover(*this);
+    }
+}
+
+void WayfireMenuButton::popdown()
+{
+    m_popover->popdown();
+    popdown_signal.emit();
+}
+
+void WayfireMenuButton::toggle()
+{
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        if (panel->get_active_popover() == NULL)
+        {
+            popup();
+        } else
+        {
+            popdown();
+        }
+    }
+}
+
+bool WayfireMenuButton::is_popup_visible()
+{
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        return panel->get_active_popover() == this;
+    }
+
+    return false;
 }

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,37 +1,118 @@
 #include "wf-popover.hpp"
+#include "gtkmm/eventcontrollermotion.h"
+#include "gtkmm/gesture.h"
+#include "gtkmm/gestureclick.h"
+#include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
+#include <cstddef>
+#include <memory>
 
-WayfireMenuButton::WayfireMenuButton(const std::string& section) :
+/* Helper to get panel from button. NULL if not added to one */
+WayfireAutohidingWindow *get_panel(WayfireMenuButton *button)
+{
+    auto window = button->get_root();
+    if (!window)
+    {
+        return NULL;
+    }
+
+    auto autohide_window = dynamic_cast<WayfireAutohidingWindow*>(window);
+    return autohide_window;
+}
+
+WayfirePopover::WayfirePopover(std::string class_name, std::string option_name)
+{
+    popover.add_css_class(class_name + "-popover");
+}
+
+void WayfirePopover::set_child(Gtk::Widget & widget)
+{
+    popover.set_child(widget);
+}
+
+Gtk::Widget*WayfirePopover::get_child()
+{
+    return popover.get_child();
+}
+
+void WayfirePopover::set_parent(Gtk::Widget & parent)
+{
+    gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(parent.gobj()));
+}
+
+void WayfirePopover::unset_parent()
+{
+    gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
+}
+
+void WayfirePopover::popup()
+{
+    popover.popup();
+}
+
+void WayfirePopover::popdown()
+{
+    popover.popdown();
+}
+
+WayfireMenuButton::WayfireMenuButton(const std::string& section, const std::string class_name,
+    const std::string option_name) :
     panel_position{section + "/position"}
 {
-    add_css_class("flat");
+    add_css_class(class_name);
 
-    auto cb = [=] ()
+    m_popover = std::make_shared<WayfirePopover>(class_name, option_name);
+    m_popover->set_parent(*this);
+
+    auto click_gesture = Gtk::GestureClick::create();
+    click_gesture->set_button(1);
+    /* Catch a press-start */
+    signals.push_back(click_gesture->signal_pressed().connect(
+        [=] (int btn, double x, double y)
     {
-        if (panel_position.value() == "bottom")
+        click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
+    }));
+    /* Action on release */
+    signals.push_back(click_gesture->signal_released().connect(
+        [=] (int, double, double)
+    {
+        toggle();
+    }));
+
+    /* Moved to another menu */
+    auto motion_gesture = Gtk::EventControllerMotion::create();
+    signals.push_back(motion_gesture->signal_enter().connect(
+        [=] (double, double)
+    {
+        auto panel = get_panel(this);
+        if (panel)
         {
-            set_direction(Gtk::ArrowType::UP);
-        } else if (panel_position.value() == "left")
-        {
-            set_direction(Gtk::ArrowType::RIGHT);
-        } else if (panel_position.value() == "right")
-        {
-            set_direction(Gtk::ArrowType::LEFT);
-        } else // top, is also the fallback when invalid
-        {
-            set_direction(Gtk::ArrowType::DOWN);
+            auto current = panel->get_active_popover();
+            if ((current != nullptr) && (current != this))
+            {
+                panel->get_active_popover()->popdown();
+                popup();
+            }
         }
+    }));
 
-        this->unset_popover();
-        set_popover(m_popover);
-    };
-    panel_position.set_callback(cb);
-    cb();
 
-    m_popover.signal_show().connect([=]
+    add_controller(click_gesture);
+    add_controller(motion_gesture);
+}
+
+WayfireMenuButton::WayfireMenuButton(const std::string& section, std::string name) :
+    WayfireMenuButton(section, name, name)
+{}
+
+WayfireMenuButton::~WayfireMenuButton()
+{
+    for (auto signal : signals)
     {
-        set_active_on_window();
-    });
+        signal.disconnect();
+    }
+
+    m_popover->unset_parent();
 }
 
 void WayfireMenuButton::set_keyboard_interactive(bool interactive)
@@ -56,16 +137,10 @@ bool WayfireMenuButton::is_popover_focused() const
 
 void WayfireMenuButton::set_active_on_window()
 {
-    auto window = this->get_parent();
-    while (window && window->get_parent())
+    auto panel = get_panel(this);
+    if (panel)
     {
-        window = window->get_parent();
-    }
-
-    auto autohide_window = dynamic_cast<WayfireAutohidingWindow*>(window);
-    if (autohide_window)
-    {
-        autohide_window->set_active_popover(*this);
+        panel->set_active_popover(*this);
     }
 }
 
@@ -73,4 +148,57 @@ void WayfireMenuButton::grab_focus()
 {
     set_keyboard_interactive();
     set_active_on_window(); // actually grab focus
+}
+
+void WayfireMenuButton::set_popover_child(Gtk::Widget & widget)
+{
+    m_popover->set_child(widget);
+}
+
+Gtk::Widget*WayfireMenuButton::get_popover_child()
+{
+    return m_popover->get_child();
+}
+
+void WayfireMenuButton::popup()
+{
+    m_popover->popup();
+    popup_signal.emit();
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        panel->set_active_popover(*this);
+    }
+}
+
+void WayfireMenuButton::popdown()
+{
+    m_popover->popdown();
+    popdown_signal.emit();
+}
+
+void WayfireMenuButton::toggle()
+{
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        if (panel->get_active_popover() == NULL)
+        {
+            popup();
+        } else
+        {
+            popdown();
+        }
+    }
+}
+
+bool WayfireMenuButton::is_popup_visible()
+{
+    auto panel = get_panel(this);
+    if (panel)
+    {
+        return panel->get_active_popover() == this;
+    }
+
+    return false;
 }

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -42,8 +42,14 @@ void WayfireMenuWidget::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)
     menu.set_menu_model(new_menu);
 }
 
+bool WayfireMenuWidget::is_manual_popup()
+{
+    return this->autohide;
+}
+
 void WayfireMenuWidget::popup(bool autohide)
 {
+    this->autohide = autohide;
     cancel_timer();
     auto panel = get_panel(this);
     if (!panel)

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -9,6 +9,7 @@
 #include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
 #include <cstddef>
+#include <cstdio>
 #include <iostream>
 #include <memory>
 #include <gtk4-layer-shell.h>
@@ -149,6 +150,13 @@ void WayfireMenuWidget::open_on(int button)
         click_signal.disconnect();
     }
 
+    click_signals.clear();
+
+    if (previous_controller != nullptr)
+    {
+        remove_controller(previous_controller);
+    }
+
     if (button < 0)
     {
         return;
@@ -168,6 +176,7 @@ void WayfireMenuWidget::open_on(int button)
         toggle();
     }));
     add_controller(click_gesture);
+    previous_controller = click_gesture;
 }
 
 WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::string class_name,

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -185,6 +185,8 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     scroll.set_propagate_natural_height(true);
     scroll.set_propagate_natural_width(true);
 
+    popover.set_autohide(false);
+
     gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(this->gobj()));
     gtk_widget_set_parent(GTK_WIDGET(menu.gobj()), GTK_WIDGET(this->gobj()));
     /* Moved to another menu */

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -1,19 +1,10 @@
-#include "wf-popover.hpp"
-#include "giomm/menumodel.h"
-#include "glib.h"
-#include "glibmm.h"
-#include "glibmm/main.h"
-#include "gtk/gtk.h"
-#include "gtkmm/eventcontrollermotion.h"
-#include "gtkmm/gestureclick.h"
-#include "gtkmm/viewport.h"
-#include "gtkmm/widget.h"
-#include "wf-autohide-window.hpp"
 #include <cstddef>
 #include <cstdio>
-#include <iostream>
 #include <memory>
 #include <gtk4-layer-shell.h>
+
+#include "wf-popover.hpp"
+#include "wf-autohide-window.hpp"
 
 /* Helper to get panel from button. NULL if not added to one */
 WayfireAutohidingWindow *get_panel(Gtk::Widget *button)

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -144,7 +144,7 @@ void WayfireMenuWidget::popdown()
 
 void WayfireMenuWidget::open_on(int button)
 {
-    if (click_signal)
+    for (auto click_signal : click_signals)
     {
         click_signal.disconnect();
     }
@@ -156,12 +156,17 @@ void WayfireMenuWidget::open_on(int button)
 
     auto click_gesture = Gtk::GestureClick::create();
     click_gesture->set_button(button);
+    click_signals.push_back(click_gesture->signal_pressed().connect(
+        [=] (int, double, double)
+    {
+        click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
+    }));
     /* Action on release */
-    click_signal = click_gesture->signal_released().connect(
+    click_signals.push_back(click_gesture->signal_released().connect(
         [=] (int, double, double)
     {
         toggle();
-    });
+    }));
     add_controller(click_gesture);
 }
 
@@ -244,8 +249,12 @@ WayfireMenuWidget::~WayfireMenuWidget()
         signal.disconnect();
     }
 
+    for (auto click_signal : click_signals)
+    {
+        click_signal.disconnect();
+    }
+
     timer_signal.disconnect();
-    click_signal.disconnect();
 
     gtk_widget_unparent(GTK_WIDGET(popover.gobj()));
     gtk_widget_unparent(GTK_WIDGET(menu.gobj()));
@@ -286,23 +295,18 @@ Gtk::Widget*WayfireMenuWidget::get_popup_child()
 
 void WayfireMenuWidget::toggle()
 {
-    Glib::signal_idle().connect([=] ()
+    auto panel = get_panel(this);
+    if (panel)
     {
-        auto panel = get_panel(this);
-        if (panel)
+        WayfireMenuWidget *popover = panel->get_active_popover();
+        if (popover == NULL)
         {
-            WayfireMenuWidget *popover = panel->get_active_popover();
-            if (popover == NULL)
-            {
-                popup();
-            } else
-            {
-                popover->popdown();
-            }
+            popup();
+        } else
+        {
+            popover->popdown();
         }
-
-        return G_SOURCE_REMOVE;
-    });
+    }
 }
 
 bool WayfireMenuWidget::is_popup_visible()

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -6,6 +6,7 @@
 #include "gtk/gtk.h"
 #include "gtkmm/eventcontrollermotion.h"
 #include "gtkmm/gestureclick.h"
+#include "gtkmm/viewport.h"
 #include "gtkmm/widget.h"
 #include "wf-autohide-window.hpp"
 #include <cstddef>
@@ -299,7 +300,14 @@ void WayfireMenuWidget::set_popup_child(Gtk::Widget & widget)
 
 Gtk::Widget*WayfireMenuWidget::get_popup_child()
 {
-    return popover.get_child();
+    auto child = scroll.get_child();
+    // the scrollable window wraps the child given to it in a viewport if it is not scrollable
+    if (auto *viewport = dynamic_cast<Gtk::Viewport*>(child))
+    {
+        return viewport->get_child();
+    }
+
+    return child;
 }
 
 void WayfireMenuWidget::toggle()

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -193,6 +193,27 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
 
     popover.set_autohide(false);
 
+    auto panel_position_changed = [=] ()
+    {
+        auto pos = panel_position.value();
+        if (pos == "top")
+        {
+            popover.set_position(Gtk::PositionType::BOTTOM);
+        } else if (pos == "bottom")
+        {
+            popover.set_position(Gtk::PositionType::TOP);
+        } else if (pos == "left")
+        {
+            popover.set_position(Gtk::PositionType::RIGHT);
+        } else if (pos == "right")
+        {
+            popover.set_position(Gtk::PositionType::LEFT);
+        }
+    };
+
+    panel_position_changed();
+    panel_position.set_callback(panel_position_changed);
+
     gtk_widget_set_parent(GTK_WIDGET(popover.gobj()), GTK_WIDGET(this->gobj()));
     gtk_widget_set_parent(GTK_WIDGET(menu.gobj()), GTK_WIDGET(this->gobj()));
     /* Moved to another menu */

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -380,3 +380,8 @@ void WayfireMenuWidget::set_timer(int millis)
         return G_SOURCE_REMOVE;
     }, millis);
 }
+
+Gtk::ScrolledWindow& WayfireMenuWidget::get_scroll()
+{
+    return scroll;
+}

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -42,7 +42,7 @@ void WayfireMenuWidget::set_menu_model(Glib::RefPtr<Gio::MenuModel> new_menu)
     menu.set_menu_model(new_menu);
 }
 
-void WayfireMenuWidget::popup()
+void WayfireMenuWidget::popup(bool autohide)
 {
     cancel_timer();
     auto panel = get_panel(this);
@@ -66,6 +66,7 @@ void WayfireMenuWidget::popup()
             fullscreen->show();
         } else
         {
+            popover.set_autohide(autohide);
             popover.popup();
         }
     } else
@@ -105,7 +106,7 @@ void WayfireMenuWidget::popup_timed(int millis)
         return;
     }
 
-    popup();
+    popup(false);
     set_timer(millis);
 }
 
@@ -190,8 +191,6 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);
     scroll.set_propagate_natural_height(true);
     scroll.set_propagate_natural_width(true);
-
-    popover.set_autohide(false);
 
     auto panel_position_changed = [=] ()
     {

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -66,6 +66,7 @@ class WayfireMenuWidget : public Gtk::Box
     sigc::connection click_signal;
 
     type_signal_simple popup_signal, popdown_signal;
+    WfOption<bool> menus_motion{"panel/menus_change_motion"};
 
   public:
     WayfireMenuWidget(const std::string& config_section,

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -2,6 +2,7 @@
 
 #include "giomm/menumodel.h"
 #include "glibmm/refptr.h"
+#include "gtkmm/scrolledwindow.h"
 #include <gtkmm/widget.h>
 #include <sigc++/connection.h>
 #include <sigc++/signal.h>
@@ -20,6 +21,7 @@ using type_signal_simple = sigc::signal<void (void)>;
 class WayfirePopup
 {
   private:
+    Gtk::ScrolledWindow scroll;
     Gtk::Popover popover;
     Gtk::PopoverMenu menu;
     bool use_menu;

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -1,14 +1,41 @@
 #pragma once
 
-#include <gtkmm/menubutton.h>
+#include "gtkmm/widget.h"
+#include "sigc++/connection.h"
+#include "sigc++/signal.h"
+#include <gtkmm/box.h>
 #include <gtkmm/popover.h>
+#include <memory>
 #include <wf-option-wrap.hpp>
+
+using type_signal_simple = sigc::signal<void (void)>;
+
+/**
+ * A Popover subclass for WayfireMenuButton
+ */
+class WayfirePopover
+{
+  private:
+    Gtk::Popover popover;
+
+  public:
+    WayfirePopover(std::string class_name, std::string option_name);
+
+    void set_child(Gtk::Widget & widget);
+    Gtk::Widget *get_child();
+
+    void popup();
+    void popdown();
+
+    void set_parent(Gtk::Widget & widget);
+    void unset_parent();
+};
 
 /**
  * A button which shows a popover on click. It adjusts the popup position
  * automatically based on panel position (valid values are "top" and "bottom")
  */
-class WayfireMenuButton : public Gtk::MenuButton
+class WayfireMenuButton : public Gtk::Box
 {
     bool interactive = true;
     bool has_focus   = false;
@@ -21,12 +48,36 @@ class WayfireMenuButton : public Gtk::MenuButton
     /* Set the has_focus property */
     void set_has_focus(bool focus);
 
-  public:
-    Gtk::Popover m_popover;
+    std::shared_ptr<WayfirePopover> m_popover;
 
-    WayfireMenuButton(const std::string& config_section);
-    virtual ~WayfireMenuButton()
-    {}
+    std::vector<sigc::connection> signals;
+
+    type_signal_simple popup_signal, popdown_signal;
+
+  public:
+    WayfireMenuButton(const std::string& config_section,
+        const std::string name);
+    WayfireMenuButton(const std::string& config_section,
+        const std::string css_name,
+        const std::string option_name);
+    ~WayfireMenuButton();
+
+    type_signal_simple signal_popup()
+    {
+        return popup_signal;
+    }
+
+    type_signal_simple signal_popdown()
+    {
+        return popdown_signal;
+    }
+
+    /**
+     * Set popover child
+     */
+    void set_popover_child(Gtk::Widget & child);
+
+    Gtk::Widget *get_popover_child();
 
     /**
      * Set whether the popup should grab input focus when opened
@@ -47,4 +98,8 @@ class WayfireMenuButton : public Gtk::MenuButton
      * NOTE: this works only if the popover was already opened.
      */
     void grab_focus();
+    void popup();
+    void popdown();
+    void toggle();
+    bool is_popup_visible();
 };

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -1,26 +1,36 @@
 #pragma once
 
-#include "gtkmm/widget.h"
-#include "sigc++/connection.h"
-#include "sigc++/signal.h"
+#include "giomm/menumodel.h"
+#include "glibmm/refptr.h"
+#include <gtkmm/widget.h>
+#include <sigc++/connection.h>
+#include <sigc++/signal.h>
 #include <gtkmm/box.h>
 #include <gtkmm/popover.h>
+#include <gtkmm/popovermenu.h>
 #include <memory>
+#include <vector>
 #include <wf-option-wrap.hpp>
 
 using type_signal_simple = sigc::signal<void (void)>;
 
 /**
- * A Popover subclass for WayfireMenuButton
+ * A popup subclass for WayfireMenuButton
  */
-class WayfirePopover
+class WayfirePopup
 {
   private:
     Gtk::Popover popover;
+    Gtk::PopoverMenu menu;
+    bool use_menu;
+
+    std::vector<sigc::connection> signals;
 
   public:
-    WayfirePopover(std::string class_name, std::string option_name);
+    WayfirePopup(std::string class_name, std::string option_name);
+    ~WayfirePopup();
 
+    void set_menu_model(Glib::RefPtr<Gio::MenuModel> menu);
     void set_child(Gtk::Widget & widget);
     Gtk::Widget *get_child();
 
@@ -32,10 +42,10 @@ class WayfirePopover
 };
 
 /**
- * A button which shows a popover on click. It adjusts the popup position
+ * A button which shows a popup on click. It adjusts the popup position
  * automatically based on panel position (valid values are "top" and "bottom")
  */
-class WayfireMenuButton : public Gtk::Box
+class WayfireMenuWidget : public Gtk::Box
 {
     bool interactive = true;
     bool has_focus   = false;
@@ -48,36 +58,39 @@ class WayfireMenuButton : public Gtk::Box
     /* Set the has_focus property */
     void set_has_focus(bool focus);
 
-    std::shared_ptr<WayfirePopover> m_popover;
+    std::shared_ptr<WayfirePopup> m_popup;
 
     std::vector<sigc::connection> signals;
+    sigc::connection click_signal;
 
     type_signal_simple popup_signal, popdown_signal;
 
   public:
-    WayfireMenuButton(const std::string& config_section,
+    WayfireMenuWidget(const std::string& config_section,
         const std::string name);
-    WayfireMenuButton(const std::string& config_section,
+    WayfireMenuWidget(const std::string& config_section,
         const std::string css_name,
         const std::string option_name);
-    ~WayfireMenuButton();
+    ~WayfireMenuWidget();
 
+    /* Called when the popup is shown */
     type_signal_simple signal_popup()
     {
         return popup_signal;
     }
 
+    /* Called when the popup is hidden */
     type_signal_simple signal_popdown()
     {
         return popdown_signal;
     }
 
     /**
-     * Set popover child
+     * Set popup child
      */
-    void set_popover_child(Gtk::Widget & child);
+    void set_popup_child(Gtk::Widget & child);
 
-    Gtk::Widget *get_popover_child();
+    Gtk::Widget *get_popup_child();
 
     /**
      * Set whether the popup should grab input focus when opened
@@ -88,18 +101,30 @@ class WayfireMenuButton : public Gtk::Box
     /** @return Whether the menu button interacts with the keyboard */
     bool is_keyboard_interactive() const;
 
-    /** @return Whether the popover currently has keyboard focus */
-    bool is_popover_focused() const;
+    /** @return Whether the popup currently has keyboard focus */
+    bool is_popup_focused() const;
 
     /**
      * Grab the keyboard focus.
-     * Also sets the popover to keyboard interactive.
+     * Also sets the popup to keyboard interactive.
      *
-     * NOTE: this works only if the popover was already opened.
+     * NOTE: this works only if the popup was already opened.
      */
     void grab_focus();
+
+    /* Open the connected popup */
     void popup();
+    /* Close the connected popup */
     void popdown();
+    /* Toggle the popup state of the connected popup */
     void toggle();
+    /* Returns true if this is the open popup for this panel */
     bool is_popup_visible();
+
+    /* Use a specific mouse button to open menu. Skip this if you're handling presses in-widget. If button < 0
+     * then this callback is removed  */
+    void open_on(int button);
+
+    /* Set the MenuModel of the popup. Masks the child set by set_popup_child */
+    void set_menu_model(Glib::RefPtr<Gio::MenuModel>);
 };

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -16,59 +16,46 @@
 using type_signal_simple = sigc::signal<void (void)>;
 
 /**
- * A popup subclass for WayfireMenuButton
- */
-class WayfirePopup
-{
-  private:
-    Gtk::ScrolledWindow scroll;
-    Gtk::Popover popover;
-    Gtk::PopoverMenu menu;
-    bool use_menu;
-
-    std::vector<sigc::connection> signals;
-
-  public:
-    WayfirePopup(std::string class_name, std::string option_name);
-    ~WayfirePopup();
-
-    void set_menu_model(Glib::RefPtr<Gio::MenuModel> menu);
-    void set_child(Gtk::Widget & widget);
-    Gtk::Widget *get_child();
-
-    void popup();
-    void popdown();
-
-    void set_parent(Gtk::Widget & widget);
-    void unset_parent();
-};
-
-/**
  * A button which shows a popup on click. It adjusts the popup position
  * automatically based on panel position (valid values are "top" and "bottom")
  */
 class WayfireMenuWidget : public Gtk::Box
 {
+  private:
+    Gtk::ScrolledWindow scroll;
+    Gtk::Popover popover;
+    Gtk::PopoverMenu menu;
+    Glib::RefPtr<Gtk::Window> fullscreen;
+    bool use_menu = false, use_widget = false;
     bool interactive = true;
-    bool has_focus   = false;
     WfOption<std::string> panel_position;
 
     /* Make the menu button active on its AutohideWindow */
     void set_active_on_window();
 
     friend class WayfireAutohidingWindow;
-    /* Set the has_focus property */
-    void set_has_focus(bool focus);
 
-    std::shared_ptr<WayfirePopup> m_popup;
-
+    sigc::connection click_signal, timer_signal;
     std::vector<sigc::connection> signals;
-    sigc::connection click_signal;
+    std::string class_name;
+
+    void cancel_timer();
+    void set_timer(int millis);
 
     type_signal_simple popup_signal, popdown_signal;
     WfOption<bool> menus_motion{"panel/menus_change_motion"};
 
   public:
+
+    void set_no_child();
+    void set_menu_model(Glib::RefPtr<Gio::MenuModel> menu);
+    void set_child(Gtk::Widget & widget);
+    Gtk::Widget *get_child();
+
+    void popup();
+    void popup_timed(int millis);
+    void popdown();
+
     WayfireMenuWidget(const std::string& config_section,
         const std::string name);
     WayfireMenuWidget(const std::string& config_section,
@@ -104,21 +91,6 @@ class WayfireMenuWidget : public Gtk::Box
     /** @return Whether the menu button interacts with the keyboard */
     bool is_keyboard_interactive() const;
 
-    /** @return Whether the popup currently has keyboard focus */
-    bool is_popup_focused() const;
-
-    /**
-     * Grab the keyboard focus.
-     * Also sets the popup to keyboard interactive.
-     *
-     * NOTE: this works only if the popup was already opened.
-     */
-    void grab_focus();
-
-    /* Open the connected popup */
-    void popup();
-    /* Close the connected popup */
-    void popdown();
     /* Toggle the popup state of the connected popup */
     void toggle();
     /* Returns true if this is the open popup for this panel */
@@ -127,7 +99,5 @@ class WayfireMenuWidget : public Gtk::Box
     /* Use a specific mouse button to open menu. Skip this if you're handling presses in-widget. If button < 0
      * then this callback is removed  */
     void open_on(int button);
-
-    /* Set the MenuModel of the popup. Masks the child set by set_popup_child */
-    void set_menu_model(Glib::RefPtr<Gio::MenuModel>);
+    void set_fullscreen(bool fs);
 };

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -85,6 +85,8 @@ class WayfireMenuWidget : public Gtk::Box
 
     Gtk::Widget *get_popup_child();
 
+    Gtk::ScrolledWindow& get_scroll();
+
     /**
      * Set whether the popup should grab input focus when opened
      * By default, the menu button interacts with the keyboard.

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -1,16 +1,11 @@
 #pragma once
 
-#include "giomm/menumodel.h"
-#include "glibmm/refptr.h"
-#include "gtkmm/gestureclick.h"
-#include "gtkmm/scrolledwindow.h"
-#include <gtkmm/widget.h>
+#include <glibmm.h>
+#include <giomm.h>
+#include <gtkmm.h>
+
 #include <sigc++/connection.h>
 #include <sigc++/signal.h>
-#include <gtkmm/box.h>
-#include <gtkmm/popover.h>
-#include <gtkmm/popovermenu.h>
-#include <memory>
 #include <vector>
 #include <wf-option-wrap.hpp>
 

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -2,6 +2,7 @@
 
 #include "giomm/menumodel.h"
 #include "glibmm/refptr.h"
+#include "gtkmm/gestureclick.h"
 #include "gtkmm/scrolledwindow.h"
 #include <gtkmm/widget.h>
 #include <sigc++/connection.h>
@@ -29,6 +30,7 @@ class WayfireMenuWidget : public Gtk::Box
     bool use_menu = false, use_widget = false;
     bool interactive = false;
     WfOption<std::string> panel_position;
+    Glib::RefPtr<Gtk::GestureClick> previous_controller = nullptr;
 
     /* Make the menu button active on its AutohideWindow */
     void set_active_on_window();

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -50,7 +50,7 @@ class WayfireMenuWidget : public Gtk::Box
     void set_child(Gtk::Widget & widget);
     Gtk::Widget *get_child();
 
-    void popup();
+    void popup(bool autohide = true);
     void popup_timed(int millis);
     void popdown();
 

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -40,6 +40,8 @@ class WayfireMenuWidget : public Gtk::Box
     void cancel_timer();
     void set_timer(int millis);
 
+    bool autohide = true;
+
     type_signal_simple popup_signal, popdown_signal;
     WfOption<bool> menus_motion{"panel/menus_change_motion"};
 
@@ -49,6 +51,8 @@ class WayfireMenuWidget : public Gtk::Box
     void set_menu_model(Glib::RefPtr<Gio::MenuModel> menu);
     void set_child(Gtk::Widget & widget);
     Gtk::Widget *get_child();
+
+    bool is_manual_popup();
 
     void popup(bool autohide = true);
     void popup_timed(int millis);

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -27,7 +27,7 @@ class WayfireMenuWidget : public Gtk::Box
     Gtk::PopoverMenu menu;
     Glib::RefPtr<Gtk::Window> fullscreen;
     bool use_menu = false, use_widget = false;
-    bool interactive = true;
+    bool interactive = false;
     WfOption<std::string> panel_position;
 
     /* Make the menu button active on its AutohideWindow */
@@ -86,7 +86,7 @@ class WayfireMenuWidget : public Gtk::Box
      * Set whether the popup should grab input focus when opened
      * By default, the menu button interacts with the keyboard.
      */
-    void set_keyboard_interactive(bool interactive = true);
+    void set_keyboard_interactive(bool interactive);
 
     /** @return Whether the menu button interacts with the keyboard */
     bool is_keyboard_interactive() const;

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -35,7 +35,8 @@ class WayfireMenuWidget : public Gtk::Box
 
     friend class WayfireAutohidingWindow;
 
-    sigc::connection click_signal, timer_signal;
+    sigc::connection timer_signal;
+    std::vector<sigc::connection> click_signals;
     std::vector<sigc::connection> signals;
     std::string class_name;
 

--- a/src/util/wf-shell-app.hpp
+++ b/src/util/wf-shell-app.hpp
@@ -17,7 +17,7 @@ using GMonitor = Glib::RefPtr<Gdk::Monitor>;
  */
 struct WayfireOutput
 {
-    GMonitor monitor;
+    GMonitor monitor = nullptr;
     wl_output *wo;
     zwf_output_v2 *output;
     sigc::signal<void()> toggle_menu_signal();


### PR DESCRIPTION
Refactor internal WayfireMenuButton to no longer actually be a menu button

MenuButton was originally chosen as it was the only way I had found to make a popover-menu for panel widgets. 

We put a fair bit of extra code to make MenuButton not actually be a menubutton. So this PR will standardise an interface for all Popup-based widgets without each one having to fight to not look like a button

Advantages over not having this PR:
- Fixed popover too big for entire screen at the source
- Moved autohide and layer shell logic out of individual widgets.
- Added option for popup-menu to follow mouse across other popup-menu widgets.
- class 'with-content' when a popup of any kind is attached
- class 'selected' when this specific widget has its popup shown
- users custom themes don't need to carefully unset all the button-specific css rules from their theme
