### PR TITLE
wp-mixer, tray: fix two SIGSEGV crashes from missing null checks

### DIFF
--- a/src/panel/widgets/tray/host.cpp
+++ b/src/panel/widgets/tray/host.cpp
@@ -48,9 +48,12 @@ void StatusNotifierHost::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connectio
             });
             Glib::Variant<std::vector<Glib::ustring>> registred_items_var;
             watcher_proxy->get_cached_property(registred_items_var, "RegisteredStatusNotifierItems");
-            for (const auto & service : registred_items_var.get())
+            if (registred_items_var)
             {
-                tray->add_item(service);
+                for (const auto & service : registred_items_var.get())
+                {
+                    tray->add_item(service);
+                }
             }
         });
     },

--- a/src/panel/widgets/wp-mixer/wp-common.cpp
+++ b/src/panel/widgets/wp-mixer/wp-common.cpp
@@ -209,24 +209,22 @@ void WpCommon::on_mixer_changed(gpointer mixer_api, guint id, gpointer data)
     // for each widget
     for (auto widget : instance->widgets)
     {
-        WfWpControl *control;
+        WfWpControl *control = nullptr;
 
-        // first, find the appropiate control
+        // first, find the appropriate control
         for (auto & it : widget->objects_to_controls)
         {
-            WpPipewireObject *obj = it.first;
-            control = it.second.get();
-            if (wp_proxy_get_bound_id(WP_PROXY(obj)) == id)
+            if (wp_proxy_get_bound_id(WP_PROXY(it.first)) == id)
             {
+                control = it.second.get();
                 break;
             }
+        }
 
-            // if we are at the end and still no match
-            if (it.first == widget->objects_to_controls.end()->first)
-            {
-                std::cerr << "Wireplumber mixer could not find control for wp object";
-                return;
-            }
+        if (!control)
+        {
+            std::cerr << "Wireplumber mixer could not find control for wp object\n";
+            continue;
         }
 
         const auto update_icons = [&] ()


### PR DESCRIPTION
## Fixes two independent SIGSEGV crashes

---

### 1. wp-mixer: uninitialized control pointer in `on_mixer_changed`

**Crash address:** `0xffffffffffffffe8` (-0x18 — method call on null/freed object)

**Stack trace:**
```
#0  Gtk::ToggleButton::set_active(bool)  [libgtkmm-4.0.so.0]
#1  <wf-panel + 0xc3257>
#2  g_signal_emit  [libgobject-2.0.so.0]
#3  libwireplumber-module-mixer-api.so
```

**Root cause:** `control` is declared uninitialized. Two bugs in the search loop:
1. If `objects_to_controls` is empty (e.g. during startup or after restart), the loop body never executes and `control` remains uninitialized — execution continues and calls `control->set_btn_status_no_callbk()` on garbage.
2. The end-of-loop check dereferences `map::end()` (UB). In a range-for loop the iterator never equals `end()`, so if no matching ID is found the loop exits with `control` pointing to the last element (wrong object).

**Fix:** Initialize `control` to `nullptr`, remove the broken `end()` dereference, and use a post-loop null check. Changed `return` to `continue` so remaining widgets still get updated.

---

### 2. tray: null `GVariant` crash in `on_bus_acquired`

**Stack trace:**
```
#0  g_bit_lock_and_get       [libglib-2.0.so.0]
#1  g_variant_n_children     [libglib-2.0.so.0]
#2  Glib::Variant<std::vector<Glib::ustring>>::get()  [libglibmm-2.68.so.1]
#3  StatusNotifierHost::on_bus_acquired lambda  [wf-panel]
```

**Root cause:** `get_cached_property` may leave the variant uninitialized if `RegisteredStatusNotifierItems` is not yet in the D-Bus proxy cache (common on fast restart before the watcher proxy has fully synced). Calling `.get()` on a null `Glib::Variant` calls `g_variant_n_children(nullptr)` → SIGSEGV.

**Fix:** Guard the loop with a null check on the variant before calling `.get()`.

---

## Tested on
- CachyOS (Arch-based), kernel 7.0.0-1-cachyos
- wf-shell r464.f926b19, WirePlumber 0.5.14, PipeWire 1.6.3
- Wayfire (Wayland), dual monitor setup
- Both crashes reproduced and confirmed fixed with patched binary