### PR TITLE
chore : clean up casts of WfOptions

### DIFF
--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -49,7 +49,7 @@ class WfDock::impl
         window->add_css_class("wf-dock");
         window->set_child(box);
 
-        if ((std::string)css_path != "")
+        if (css_path.value() != "")
         {
             auto css = load_css_from_path(css_path);
             if (css)

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -58,22 +58,22 @@ class WayfirePanel::impl
     WfOption<std::string> panel_layer{"panel/layer"};
     std::function<void()> set_panel_layer = [=] ()
     {
-        if ((std::string)panel_layer == "overlay")
+        if (panel_layer.value() == "overlay")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
         }
 
-        if ((std::string)panel_layer == "top")
+        if (panel_layer.value() == "top")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_TOP);
         }
 
-        if ((std::string)panel_layer == "bottom")
+        if (panel_layer.value() == "bottom")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
         }
 
-        if ((std::string)panel_layer == "background")
+        if (panel_layer.value() == "background")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
         }
@@ -415,15 +415,15 @@ class WayfirePanel::impl
     {
         left_widgets_opt.set_callback([=] ()
         {
-            reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
+            reload_widgets(left_widgets_opt.value(), left_widgets, left_box);
         });
         right_widgets_opt.set_callback([=] ()
         {
-            reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
+            reload_widgets(right_widgets_opt.value(), right_widgets, right_box);
         });
         center_widgets_opt.set_callback([=] ()
         {
-            reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
+            reload_widgets(center_widgets_opt.value(), center_widgets, center_box);
             if (center_box.get_children().empty())
             {
                 content_box.unset_center_widget();
@@ -433,9 +433,9 @@ class WayfirePanel::impl
             }
         });
 
-        reload_widgets((std::string)left_widgets_opt, left_widgets, left_box);
-        reload_widgets((std::string)right_widgets_opt, right_widgets, right_box);
-        reload_widgets((std::string)center_widgets_opt, center_widgets, center_box);
+        reload_widgets(left_widgets_opt.value(), left_widgets, left_box);
+        reload_widgets(right_widgets_opt.value(), right_widgets, right_box);
+        reload_widgets(center_widgets_opt.value(), center_widgets, center_box);
 
         if (center_box.get_children().empty())
         {
@@ -504,12 +504,12 @@ bool WayfirePanelApp::panel_allowed_by_config(bool allowed, std::string output_n
 {
     if (allowed)
     {
-        return std::string(*priv->panel_outputs).find("*") != std::string::npos ||
-               std::string(*priv->panel_outputs).find(output_name) != std::string::npos;
+        return priv->panel_outputs->value().find("*") != std::string::npos ||
+               priv->panel_outputs->value().find(output_name) != std::string::npos;
     } else
     {
-        return std::string(*priv->panel_outputs).find("*") == std::string::npos &&
-               std::string(*priv->panel_outputs).find(output_name) == std::string::npos;
+        return priv->panel_outputs->value().find("*") == std::string::npos &&
+               priv->panel_outputs->value().find(output_name) == std::string::npos;
     }
 }
 
@@ -584,7 +584,7 @@ void WayfirePanelApp::on_activate()
         }
 
         std::cout << std::endl << "Currently the [panel] outputs option is set to: " <<
-            std::string(*priv->panel_outputs) << std::endl;
+            priv->panel_outputs->value() << std::endl;
     }
 
     const static std::vector<std::pair<std::string, std::string>> icon_sizes_args =

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -37,7 +37,7 @@ void WayfireClock::on_calendar_shown()
 bool WayfireClock::update_label()
 {
     auto time = Glib::DateTime::create_now_local();
-    auto text = time.format((std::string)format);
+    auto text = time.format(format.value());
 
     /* Sometimes GLib::DateTime will add leading spaces. This results in
      * unevenly balanced padding around the text, which looks quite bad.
@@ -46,7 +46,7 @@ bool WayfireClock::update_label()
      * format string, * but to remove the requirement that the user does
      * something fancy, we just remove any leading spaces. */
     int i = 0;
-    while (i < (int)text.length() && text[i] == ' ')
+    while (i < text.length() && text[i] == ' ')
     {
         i++;
     }

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -697,22 +697,22 @@ void WayfireMenu::setup_popover_layout()
         Gtk::Window *window = dynamic_cast<Gtk::Window*>(button->get_root());
         WfOption<std::string> panel_layer{"panel/layer"};
 
-        if ((std::string)panel_layer == "overlay")
+        if (panel_layer.value() == "overlay")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
         }
 
-        if ((std::string)panel_layer == "top")
+        if (panel_layer.value() == "top")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_TOP);
         }
 
-        if ((std::string)panel_layer == "bottom")
+        if (panel_layer.value() == "bottom")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BOTTOM);
         }
 
-        if ((std::string)panel_layer == "background")
+        if (panel_layer.value() == "background")
         {
             gtk_layer_set_layer(window->gobj(), GTK_LAYER_SHELL_LAYER_BACKGROUND);
         }
@@ -775,37 +775,37 @@ void WayfireMenu::update_popover_layout()
 void WayfireLogoutUI::on_logout_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(logout_command).c_str(), NULL);
+    g_spawn_command_line_async(logout_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_reboot_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(reboot_command).c_str(), NULL);
+    g_spawn_command_line_async(reboot_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_shutdown_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(shutdown_command).c_str(), NULL);
+    g_spawn_command_line_async(shutdown_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_suspend_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(suspend_command).c_str(), NULL);
+    g_spawn_command_line_async(suspend_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_hibernate_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(hibernate_command).c_str(), NULL);
+    g_spawn_command_line_async(hibernate_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_switchuser_click()
 {
     ui.hide();
-    g_spawn_command_line_async(std::string(switchuser_command).c_str(), NULL);
+    g_spawn_command_line_async(switchuser_command.value().c_str(), NULL);
 }
 
 void WayfireLogoutUI::on_cancel_click()
@@ -905,9 +905,9 @@ void WayfireMenu::on_logout_click()
 {
     button->get_popover()->hide();
     fullscreen.hide();
-    if (!std::string(menu_logout_command).empty())
+    if (!menu_logout_command.value().empty())
     {
-        g_spawn_command_line_async(std::string(menu_logout_command).c_str(), NULL);
+        g_spawn_command_line_async(menu_logout_command.value().c_str(), NULL);
         return;
     }
 

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -99,9 +99,9 @@ void WayfireNetworkInfo::set_connection(std::shared_ptr<Network> network)
 
 void WayfireNetworkInfo::on_click()
 {
-    if ((std::string)click_command_opt != "default")
+    if (click_command_opt.value() != "default")
     {
-        Glib::spawn_command_line_async((std::string)click_command_opt);
+        Glib::spawn_command_line_async(click_command_opt.value());
     } else
     {
         std::string command = "env XDG_CURRENT_DESKTOP=GNOME gnome-control-center";

--- a/src/panel/widgets/window-list/layout.cpp
+++ b/src/panel/widgets/window-list/layout.cpp
@@ -17,7 +17,7 @@ void WayfireWindowListLayout::allocate_vfunc(const Gtk::Widget& widget, int widt
 
     int per_child = width / child_count;
     // user preference is ignored if too small
-    int preference = std::max(height, (int)user_size);
+    int preference = std::max(height, user_size.value());
     // At minimum use ratio of 1:1, at max use user preference
     per_child = std::max(per_child, height);
     per_child = std::min(per_child, preference);
@@ -61,7 +61,7 @@ void WayfireWindowListLayout::measure_vfunc(const Gtk::Widget& widget, Gtk::Orie
         int child_count = widget.get_children().size();
 
         // Use max of user preference and ratio 1:1
-        int per_child = std::max(for_size, (int)user_size);
+        int per_child = std::max(for_size, user_size.value());
 
         minimum = child_count * for_size;
         natural = per_child * child_count;


### PR DESCRIPTION
As stated in chatrooms, the preffered way going forward is to let it be implicetely cast, and if impossible use .value() instead of explicitely casting

Maybe we should add a contributing section to the wiki that mentions it