### PR TITLE
chore : remove dead and commented-out code

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -475,11 +475,6 @@ If full_span is off, both sides of the panel will take the same amount of space,
 	</group>
 	<group>
 	<_short>Tray</_short>
-	<option name="tray_smooth_scrolling_threshold" type="int">
-		<_short>Smooth Scrolling Threshold</_short>
-		<default>5</default>
-		<min>1</min>
-	</option>
 	<option name="tray_icon_size" type="int">
 		<_short>Default Icon Size</_short>
 		<default>0</default>

--- a/src/dock/toplevel.cpp
+++ b/src/dock/toplevel.cpp
@@ -177,9 +177,7 @@ static void handle_toplevel_state(void *data, toplevel_t, wl_array *state)
 }
 
 static void handle_toplevel_done(void *data, toplevel_t)
-{
-// auto impl = static_cast<WfToplevel::impl*> (data);
-}
+{}
 
 static void handle_toplevel_closed(void *data, toplevel_t handle)
 {

--- a/src/panel/widgets/command-output.cpp
+++ b/src/panel/widgets/command-output.cpp
@@ -71,11 +71,6 @@ WfCommandOutputButtons::CommandOutput::CommandOutput(const std::string & name,
 
     main_label.set_ellipsize(Pango::EllipsizeMode::END);
     main_label.set_max_width_chars(max_chars_opt);
-    max_chars_opt.set_callback([=]
-    {
-        main_label.set_max_width_chars(max_chars_opt);
-    });
-    // main_label.set_alignment(Gtk::ALIGN_CENTER);
     max_chars_opt.set_callback([this]
     {
         main_label.set_max_width_chars(max_chars_opt);
@@ -102,7 +97,6 @@ WfCommandOutputButtons::CommandOutput::CommandOutput(const std::string & name,
     }
 
     set_child(box);
-    // set_relief(Gtk::RELIEF_NONE);
 
     const auto update_output = [=] ()
     {

--- a/src/panel/widgets/language.hpp
+++ b/src/panel/widgets/language.hpp
@@ -20,7 +20,6 @@ struct Layout
 
 class WayfireLanguage : public WayfireWidget, public IIPCSubscriber
 {
-    // Gtk::Label label;
     Gtk::Button button;
     sigc::connection btn_sig;
 

--- a/src/panel/widgets/tray/item.cpp
+++ b/src/panel/widgets/tray/item.cpp
@@ -178,9 +178,6 @@ void StatusNotifierItem::setup_tooltip()
         {
             tooltip->set_icon(pixbuf);
             icon_shown = true;
-        } else
-        {
-            // tooltip->set_icon_from_name(tooltip_icon_name);
         }
 
         tooltip->set_markup(tooltip_label_text);

--- a/src/panel/widgets/tray/item.hpp
+++ b/src/panel/widgets/tray/item.hpp
@@ -14,7 +14,6 @@ class StatusNotifierItem : public Gtk::Button
 {
     guint menu_handler_id;
 
-    WfOption<int> smooth_scolling_threshold{"panel/tray_smooth_scrolling_threshold"};
     WfOption<bool> menu_on_middle_click{"panel/tray_menu_on_middle_click"};
 
     Glib::ustring dbus_name, menu_path;

--- a/src/panel/widgets/volume.hpp
+++ b/src/panel/widgets/volume.hpp
@@ -19,8 +19,6 @@ class WayfireVolume : public WayfireWidget
     WfOption<double> timeout{"panel/volume_display_timeout"};
     WfOption<double> scroll_sensitivity{"panel/volume_scroll_sensitivity"};
 
-    // void on_volume_scroll(GdkEventScroll *event);
-    // void on_volume_button_press(GdkEventButton *event);
     void on_volume_value_changed();
     bool on_popover_timeout(int timer);
 

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -400,11 +400,9 @@ class WayfireToplevel::impl
     Glib::RefPtr<Gio::Menu> menu;
     Glib::RefPtr<Gio::MenuItem> minimize, maximize, close;
     Glib::RefPtr<Gio::SimpleAction> minimize_action, maximize_action, close_action;
-    // Gtk::Box menu_box;
     Gtk::Box button_contents;
     Gtk::Image image;
     Gtk::Label label;
-    // Gtk::PopoverMenu menu;
     Glib::RefPtr<Gtk::GestureDrag> drag_gesture;
     std::vector<sigc::connection> signals;
     sigc::connection button_leave_signal;
@@ -675,11 +673,6 @@ class WayfireToplevel::impl
 
     bool drag_paused()
     {
-        /*
-         *  auto gseat = Gdk::Display::get_default()->get_default_seat()->get_wl_seat();
-         *  //auto seat  = gdk_wayland_seat_get_wl_seat(gseat->gobj());
-         *  zwlr_foreign_toplevel_handle_v1_activate(handle, gseat);
-         */
         return false;
     }
 

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -523,7 +523,6 @@ void WayfireAutohidingWindow::start_draw_timer()
 gboolean WayfireAutohidingWindow::update_animation(Glib::RefPtr<Gdk::FrameClock> frame_clock)
 {
     update_margin();
-    // this->queue_draw();
     // Once we've finished fading, stop this callback
     return autohide_animation.running() ? G_SOURCE_CONTINUE : G_SOURCE_REMOVE;
 }


### PR DESCRIPTION
The tray_smooth_scrolling_threshold was a leftover option from gtk3 version that is unused as of the gtk4 port.

Rest is a callaback getting set twice and commented-out code.