### PR TITLE
panel : mixer : change vertical layout option to general layout option

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -409,10 +409,18 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<_long>Displays the mute and set default icon on the left</_long>
 		<default>false</default>
 	</option>
-	<option name="mixer_stack_categories" type="bool">
-		<_short>Stack categories</_short>
-		<_long>Displays the outputs, inputs and streams stacked on top of each other instead of side by side</_long>
-		<default>false</default>
+	<option name="mixer_layout" type="string">
+		<_short>Layout</_short>
+		<_long>Type of layout in which to arrange the mixer</_long>
+		<default>horizontal</default>
+		<desc>
+			<value>horizontal</value>
+			<_name>Horizontal</_name>
+		</desc>
+		<desc>
+			<value>vertical</value>
+			<_name>Vertical</_name>
+		</desc>
 	</option>
 	<option name="mixer_spacing" type="int">
 		<_short>Spacing between controls</_short>

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -23,7 +23,13 @@ void WayfireMixer::reload_config()
     set_spacing(sources_box);
     set_spacing(streams_box);
 
-    master_box.set_orientation(stack_categories ? Gtk::Orientation::VERTICAL : Gtk::Orientation::HORIZONTAL);
+    if (layout.value() == "vertical")
+    {
+        master_box.set_orientation(Gtk::Orientation::VERTICAL);
+    } else // horizontal
+    {
+        master_box.set_orientation(Gtk::Orientation::HORIZONTAL);
+    }
 
     // big matching operation
     static WfOption<std::string> str_quick_target_choice{"panel/mixer_quick_target_choice"};

--- a/src/panel/widgets/mixer/mixer.hpp
+++ b/src/panel/widgets/mixer/mixer.hpp
@@ -29,7 +29,7 @@ class WayfireMixer : public WayfireWidget
     Gtk::Image main_image;
 
     WfOption<int> spacing{"panel/mixer_spacing"};
-    WfOption<bool> stack_categories{"panel/mixer_stack_categories"};
+    WfOption<std::string> layout{"panel/mixer_layout"};
 
     void on_volume_value_changed();
 


### PR DESCRIPTION
A general layout option is cleaner and clearer. The two current layouts aren’t so different, but it also allows for further layouts to be added.

#454 would be such an example of a layout.