### PR TITLE
locker : make fingerprint updates count as activity

### DIFF
--- a/src/locker/plugin/fingerprint.cpp
+++ b/src/locker/plugin/fingerprint.cpp
@@ -439,13 +439,6 @@ void WayfireLockerFingerprintPlugin::update(std::string label, std::string image
     label_contents = label;
     color_contents = color;
 
-    // the text is susceptible to be updated when the elements of the locker are otherwise hidden,
-    // notably by verification status, so something happened that we can count as activity
-    for (auto pair : WayfireLockerApp::get().window_list)
-    {
-        pair.second->window_activity();
-    }
-
     for (auto& it : widgets)
     {
         it.second->label.set_label(label);
@@ -458,6 +451,8 @@ void WayfireLockerFingerprintPlugin::update(std::string label, std::string image
         {
             widget->add_css_class(color);
         }
+
+        it.second->activity();
     }
 }
 

--- a/src/locker/plugin/fingerprint.cpp
+++ b/src/locker/plugin/fingerprint.cpp
@@ -439,6 +439,13 @@ void WayfireLockerFingerprintPlugin::update(std::string label, std::string image
     label_contents = label;
     color_contents = color;
 
+    // the text is susceptible to be updated when the elements of the locker are otherwise hidden,
+    // notably by verification status, so something happened that we can count as activity
+    for (auto pair : WayfireLockerApp::get().window_list)
+    {
+        pair.second->window_activity();
+    }
+
     for (auto& it : widgets)
     {
         it.second->label.set_label(label);


### PR DESCRIPTION
This causes the locker widgets to pop out when the fingerprint widget is updated, as it happens following user activity (fingerprint verification) or to notify the user of a change in sensor state