### PR TITLE
autohide-window : add margins to the opposite edge if autohide is disabled

### DIFF
--- a/metadata/dock.xml
+++ b/metadata/dock.xml
@@ -73,6 +73,11 @@
 		<_long>Space between the dock the edge</_long>
 		<default>0</default>
 	</option>
+	<option name="mirror_margin" type="bool">
+		<_short>Mirror margin</_short>
+		<_long>Apply the margin to both the edge and the windows.</_long>
+		<default>true</default>
+	</option>
 	<option name="edge_hotspot_size" type="int">
 		<_short>Edge hotspot size</_short>
 		<_long>The distance to the edge of screen to place the cursor in to show the dock when it's hidden.</_long>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -92,6 +92,11 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<_long>Space between the panel the edge</_long>
 		<default>0</default>
 	</option>
+	<option name="mirror_margin" type="bool">
+		<_short>Mirror margin</_short>
+		<_long>Apply the margin to both the edge and the windows.</_long>
+		<default>true</default>
+	</option>
 	<option name="edge_hotspot_size" type="int">
 		<_short>Edge hotspot size</_short>
 		<_long>The distance to the edge of screen to place the cursor in to show the panel when it's hidden.</_long>

--- a/src/util/wf-autohide-window.cpp
+++ b/src/util/wf-autohide-window.cpp
@@ -23,6 +23,7 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     autohide_show_delay{section + "/autohide_show_delay"},
     autohide_hide_delay{section + "/autohide_hide_delay"},
     edge_margin{section + "/edge_margin"},
+    mirror_margin{section + "/mirror_margin"},
     edge_hotspot_size{section + "/edge_hotspot_size"},
     adjacent_edge_hotspot_size{section + "/adjacent_edge_hotspot_size"}
 {
@@ -39,6 +40,7 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     this->position.set_callback([=] () { this->update_position(); });
     this->full_span.set_callback([=] () { this->update_position(); });
     this->edge_margin.set_callback([=] () { update_position(); });
+    this->mirror_margin.set_callback([=] () { update_position(); });
     this->update_position();
 
     const auto set_size = [=] () { this->set_size_request(minimal_width, minimal_height); };
@@ -73,7 +75,6 @@ WayfireAutohidingWindow::WayfireAutohidingWindow(WayfireOutput *output,
     this->edge_hotspot_size.set_callback([=] () { this->setup_hotspot(); });
 
     this->autohide_opt.set_callback([=] { setup_autohide(); });
-
 
     if (!output->output)
     {
@@ -204,16 +205,37 @@ void WayfireAutohidingWindow::m_show_uncertain()
 
 void WayfireAutohidingWindow::update_position()
 {
-    /* Reset old anchors */
-    gtk_layer_set_anchor(this->gobj(), GTK_LAYER_SHELL_EDGE_TOP, false);
-    gtk_layer_set_anchor(this->gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, false);
-    gtk_layer_set_anchor(this->gobj(), GTK_LAYER_SHELL_EDGE_LEFT, false);
-    gtk_layer_set_anchor(this->gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, false);
+    // reset anchors and margins
+    for (auto edge :
+     {GTK_LAYER_SHELL_EDGE_TOP, GTK_LAYER_SHELL_EDGE_BOTTOM, GTK_LAYER_SHELL_EDGE_LEFT,
+         GTK_LAYER_SHELL_EDGE_RIGHT})
+    {
+        gtk_layer_set_anchor(this->gobj(), edge, false);
+        gtk_layer_set_margin(this->gobj(), edge, 0);
+    }
 
     /* Set new anchor */
     GtkLayerShellEdge edge = get_anchor_edge(position);
     gtk_layer_set_anchor(this->gobj(), edge, true);
     gtk_layer_set_margin(this->gobj(), edge, edge_margin);
+
+    // margins on both sides of the window
+    if (mirror_margin && auto_exclusive_zone)
+    {
+        if (edge == GTK_LAYER_SHELL_EDGE_TOP)
+        {
+            gtk_layer_set_margin(this->gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, edge_margin);
+        } else if (edge == GTK_LAYER_SHELL_EDGE_BOTTOM)
+        {
+            gtk_layer_set_margin(this->gobj(), GTK_LAYER_SHELL_EDGE_TOP, edge_margin);
+        } else if (edge == GTK_LAYER_SHELL_EDGE_LEFT)
+        {
+            gtk_layer_set_margin(this->gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, edge_margin);
+        } else if (edge == GTK_LAYER_SHELL_EDGE_RIGHT)
+        {
+            gtk_layer_set_margin(this->gobj(), GTK_LAYER_SHELL_EDGE_LEFT, edge_margin);
+        }
+    }
 
     if (full_span)
     {

--- a/src/util/wf-autohide-window.hpp
+++ b/src/util/wf-autohide-window.hpp
@@ -109,6 +109,7 @@ class WayfireAutohidingWindow : public Gtk::Window
     WfOption<int> autohide_hide_delay;
 
     WfOption<int> edge_margin;
+    WfOption<bool> mirror_margin;
 
     bool auto_exclusive_zone     = !autohide_opt;
     int auto_exclusive_zone_size = 0;


### PR DESCRIPTION
The margins being mostly a matter of style, i propose that if a margin is applied and autohide is disabled, space is reserved on both sides of the window.

Without this patch applied on wayfire master (thus upcoming 0.11, this is important because it used to have a bug) :
<img width="1237" height="130" alt="image" src="https://github.com/user-attachments/assets/7a827499-13da-4e08-9c8b-5c7996efb47f" />

with :
<img width="917" height="169" alt="image" src="https://github.com/user-attachments/assets/6cb2c62b-9860-46bb-ad8c-332721857405" />