### PR TITLE
window-list: disconnect scale_factor signal on destroy (fixes SIGSEGV on window close)

### DIFF
--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -434,8 +434,8 @@ class WayfireToplevel::impl
         label.set_hexpand(true);
         label.set_halign(Gtk::Align::START);
 
-        button.property_scale_factor().signal_changed()
-            .connect(sigc::mem_fun(*this, &WayfireToplevel::impl::on_scale_update));
+        signals.push_back(button.property_scale_factor().signal_changed()
+            .connect(sigc::mem_fun(*this, &WayfireToplevel::impl::on_scale_update)));
 
 
         actions = Gio::SimpleActionGroup::create();


### PR DESCRIPTION
Since 25d9879 (window-list icon-size), wf-panel crashes with SIGSEGV when a window closes — e.g. restarting an application.

The scale_factor signal connection added in that commit is the only connection in `WayfireToplevel::impl` that is **not** stored in the `signals` vector. Every other connection is stored and disconnected in the destructor:

```cpp
for (auto signal : signals)
    signal.disconnect();
```

Because this one is untracked, it is never disconnected. When the toplevel is destroyed, the button's `scale_factor` property still changes during teardown and fires `on_scale_update()` on the freed object → `set_app_id()` → `IconProvider::image_set_icon()` on a destroyed `Gtk::Image`, crashing inside the GTK4 CSS/style chain.

**Fix:** store the connection in `signals` like all the others so it is cleaned up with them.

**Reproduce:** launch a GUI application, then close/restart it — wf-panel crashes. With this patch the panel survives repeated open/close cycles.
