### PR TITLE
panel : battery : only show power mode popover if it is available and replace the icon with a power icon if the device doesn’t have a battery

### DIFF
--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -189,7 +189,7 @@ void WayfireBatteryInfo::update_state()
                  "\n\tWayfireBatteryInfo::update_state()" << std::endl;
 }
 
-bool WayfireBatteryInfo::setup_dbus()
+bool WayfireBatteryInfo::setup_dbus_power_modes()
 {
     auto cancellable = Gio::Cancellable::create();
     connection = Gio::DBus::Connection::get_sync(Gio::DBus::BusType::SYSTEM, cancellable);
@@ -218,10 +218,25 @@ bool WayfireBatteryInfo::setup_dbus()
         {
             setup_profiles(profiles.get());
             set_current_profile(current_profile.get());
+            return true;
         } else
         {
             std::cout << "Unable to conect to Power Profiles. Continuing" << std::endl;
+            return false;
         }
+    }
+
+    return false;
+}
+
+bool WayfireBatteryInfo::setup_dbus_battery()
+{
+    auto cancellable = Gio::Cancellable::create();
+    connection = Gio::DBus::Connection::get_sync(Gio::DBus::BusType::SYSTEM, cancellable);
+    if (!connection)
+    {
+        std::cerr << "Failed to connect to dbus" << std::endl;
+        return false;
     }
 
     upower_proxy = Gio::DBus::Proxy::create_sync(connection, UPOWER_NAME,
@@ -277,11 +292,9 @@ void WayfireBatteryInfo::handle_config_reload()
 
 void WayfireBatteryInfo::init(Gtk::Box *container)
 {
-    profiles_menu = Gio::Menu::create();
-    state_action  = Gio::SimpleAction::create_radio_string("set_profile", "");
     box = std::make_unique<WayfireMenuWidget>("panel", "battery");
 
-    if (!setup_dbus())
+    if (!setup_dbus_battery())
     {
         return;
     }
@@ -294,38 +307,46 @@ void WayfireBatteryInfo::init(Gtk::Box *container)
 
     update_details();
     update_icon();
-    auto actions = Gio::SimpleActionGroup::create();
 
-    state_action->signal_activate().connect([=] (Glib::VariantBase vb)
+    if (setup_dbus_power_modes())
     {
-        // User has requested a change of state. Don't change the UI choice, let the dbus roundtrip happen to
-        // be sure.
-        if (vb.is_of_type(Glib::VariantType("s")))
+        profiles_menu = Gio::Menu::create();
+        state_action  = Gio::SimpleAction::create_radio_string("set_profile", "");
+
+        auto actions = Gio::SimpleActionGroup::create();
+
+        state_action->signal_activate().connect([=] (Glib::VariantBase vb)
         {
-            // Couldn't seem to make proxy send property back, so this will have to do
-            Glib::VariantContainerBase params = Glib::Variant<std::tuple<Glib::ustring, Glib::ustring,
-                Glib::VariantBase>>::create({POWER_PROFILE_NAME, ACTIVE_PROFILE, vb});
+            // User has requested a change of state. Don't change the UI choice,
+            // let the dbus roundtrip happen to be sure.
+            if (vb.is_of_type(Glib::VariantType("s")))
+            {
+                // Couldn't seem to make proxy send property back, so this will have to do
+                Glib::VariantContainerBase params = Glib::Variant<std::tuple<Glib::ustring, Glib::ustring,
+                    Glib::VariantBase>>::create({POWER_PROFILE_NAME, ACTIVE_PROFILE, vb});
 
-            connection->call_sync(
-                POWER_PROFILE_PATH,
-                "org.freedesktop.DBus.Properties",
-                "Set",
-                params,
-                NULL,
-                POWER_PROFILE_NAME,
-                -1,
-                Gio::DBus::CallFlags::NONE,
-                {});
-        }
-    });
+                connection->call_sync(
+                    POWER_PROFILE_PATH,
+                    "org.freedesktop.DBus.Properties",
+                    "Set",
+                    params,
+                    NULL,
+                    POWER_PROFILE_NAME,
+                    -1,
+                    Gio::DBus::CallFlags::NONE,
+                    {});
+            }
+        });
 
-    box->open_on(1);
+        actions->add_action(state_action);
 
-    actions->add_action(state_action);
-    box->insert_action_group("actions", actions);
+        box->open_on(1);
+        box->insert_action_group("actions", actions);
+        box->set_spacing(5);
+        box->set_menu_model(profiles_menu);
+    }
+
     container->append(*box);
-    box->set_spacing(5);
-    box->set_menu_model(profiles_menu);
 
     icon.property_scale_factor().signal_changed()
         .connect(sigc::mem_fun(*this, &WayfireBatteryInfo::update_icon));

--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -298,6 +298,9 @@ void WayfireBatteryInfo::handle_config_reload()
 
 void WayfireBatteryInfo::init(Gtk::Box *container)
 {
+    profiles_menu = Gio::Menu::create();
+    state_action  = Gio::SimpleAction::create_radio_string("set_profile", "");
+
     // the two features are battery displaying and power modes
     feat_bat   = setup_dbus_battery();
     feat_modes = setup_dbus_power_modes();
@@ -324,9 +327,6 @@ void WayfireBatteryInfo::init(Gtk::Box *container)
 
     if (feat_modes)
     {
-        profiles_menu = Gio::Menu::create();
-        state_action  = Gio::SimpleAction::create_radio_string("set_profile", "");
-
         auto actions = Gio::SimpleActionGroup::create();
 
         state_action->signal_activate().connect([=] (Glib::VariantBase vb)
@@ -380,9 +380,7 @@ void WayfireBatteryInfo::on_upower_properties_changed(
             {
                 auto value_string =
                     Glib::VariantBase::cast_dynamic<Glib::Variant<Glib::ustring>>(prop.second).get();
-                power_mode = value_string;
                 set_current_profile(value_string);
-                update_icon();
             }
         } else if (prop.first == PROFILES)
         {
@@ -400,7 +398,9 @@ void WayfireBatteryInfo::on_upower_properties_changed(
 
 void WayfireBatteryInfo::set_current_profile(Glib::ustring profile)
 {
+    power_mode = profile;
     state_action->set_state(Glib::Variant<Glib::ustring>::create(profile));
+    update_icon();
 }
 
 void WayfireBatteryInfo::setup_profiles(std::vector<std::map<Glib::ustring, Glib::VariantBase>> profiles)

--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -77,6 +77,12 @@ void WayfireBatteryInfo::on_properties_changed(
 
 void WayfireBatteryInfo::update_icon()
 {
+    if (!feat_bat && feat_modes)
+    {
+        icon.set_from_icon_name("power-profile-" + power_mode);
+        return;
+    }
+
     Glib::Variant<Glib::ustring> icon_name;
     display_device->get_cached_property(icon_name, ICON);
     icon.set_from_icon_name(icon_name.get());
@@ -292,23 +298,31 @@ void WayfireBatteryInfo::handle_config_reload()
 
 void WayfireBatteryInfo::init(Gtk::Box *container)
 {
-    box = std::make_unique<WayfireMenuWidget>("panel", "battery");
+    // the two features are battery displaying and power modes
+    feat_bat   = setup_dbus_battery();
+    feat_modes = setup_dbus_power_modes();
 
-    if (!setup_dbus_battery())
+    // ignore if we can’t do either
+    if (!feat_bat && !feat_modes)
     {
         return;
     }
+
+    box = std::make_unique<WayfireMenuWidget>("panel", "battery");
 
     box->append(overlay);
     overlay.set_child(icon);
     icon.add_css_class("widget-icon");
 
-    status_opt.set_callback([=] () { update_details(); });
+    if (feat_bat)
+    {
+        status_opt.set_callback([=] () { update_details(); });
+        update_details();
+    }
 
-    update_details();
     update_icon();
 
-    if (setup_dbus_power_modes())
+    if (feat_modes)
     {
         profiles_menu = Gio::Menu::create();
         state_action  = Gio::SimpleAction::create_radio_string("set_profile", "");
@@ -366,7 +380,9 @@ void WayfireBatteryInfo::on_upower_properties_changed(
             {
                 auto value_string =
                     Glib::VariantBase::cast_dynamic<Glib::Variant<Glib::ustring>>(prop.second).get();
+                power_mode = value_string;
                 set_current_profile(value_string);
+                update_icon();
             }
         } else if (prop.first == PROFILES)
         {

--- a/src/panel/widgets/battery.hpp
+++ b/src/panel/widgets/battery.hpp
@@ -39,7 +39,8 @@ class WayfireBatteryInfo : public WayfireWidget
     DBusConnection connection;
     DBusProxy upower_proxy, powerprofile_proxy, display_device;
 
-    bool setup_dbus();
+    bool setup_dbus_power_modes();
+    bool setup_dbus_battery();
 
     void update_icon();
     void update_details();

--- a/src/panel/widgets/battery.hpp
+++ b/src/panel/widgets/battery.hpp
@@ -38,9 +38,11 @@ class WayfireBatteryInfo : public WayfireWidget
 
     DBusConnection connection;
     DBusProxy upower_proxy, powerprofile_proxy, display_device;
+    std::string power_mode = "";
 
-    bool setup_dbus_power_modes();
+    bool feat_bat, feat_modes; // the available features when running
     bool setup_dbus_battery();
+    bool setup_dbus_power_modes();
 
     void update_icon();
     void update_details();


### PR DESCRIPTION
do not connect open_on if the power-profiles-daemon interface is not found, thus not letting the user open an empty popover, which would be jarring

use the power icon corresponding to the current state if the device doesn’t have a battery but power profiles switching is available

if neither are available, still ignore the widget