### PR TITLE
fix not removing views from workspace preview issues

### DIFF
--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -134,6 +134,11 @@ void WayfireWorkspaceSwitcher::clear_box()
         box.remove(*child);
     }
 
+    for (auto child : overlay.get_children())
+    {
+        overlay.remove_overlay(*child);
+    }
+
     for (auto child : mini_grid.get_children())
     {
         mini_grid.remove(*child);
@@ -723,14 +728,10 @@ void WayfireWorkspaceSwitcher::grid_remove_view(wf::json_t view_data)
     {
         if (w->id == view_data["id"].as_int())
         {
-            for (auto widget : overlay.get_children())
-            {
-                WayfireWorkspaceWindow *w = (WayfireWorkspaceWindow*)widget;
-                overlay.remove_overlay(*w);
-                auto elem = std::remove(windows.begin(), windows.end(), w);
-                windows.erase(elem, windows.end());
-                return;
-            }
+            overlay.remove_overlay(*w);
+            auto elem = std::remove(windows.begin(), windows.end(), w);
+            windows.erase(elem, windows.end());
+            return;
         }
     }
 }


### PR DESCRIPTION
* fixed not removing closed or minimalised window from workspace-switcher grid preview
  * loop and line `WayfireWorkspaceWindow *w = (WayfireWorkspaceWindow*)widget;` caused removing fist processed overlay instead of related to a closed window
* fixed not removing closed window on not current workspace from workspace-switcher grid preview
  * `windows` was cleared in `clear_box` but `overlay` child was not removed which led to overlays being duplicated when switching workspaces