### PR TITLE
use boxflow in tray and launchers to allow multi rows/columns setup

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -154,6 +154,11 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<default>0</default>
 		<min>0</min>
 	</option>
+	<option name="launchers_rows_cols" type="int">
+		<_short>Number of rows (in horizontall panels) or columns (in vertical panels) in Launchers widget</_short>
+		<default>1</default>
+		<min>1</min>
+	</option>
 	<option name="launchers" type="dynamic-list" type-hint="dict">
 		<_short>Launchers</_short>
 		<_long>Launchers</_long>
@@ -559,6 +564,11 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<_short>Space between tray icons</_short>
 		<default>5</default>
 		<min>0</min>
+	</option>
+	<option name="tray_rows_cols" type="int">
+		<_short>Number of rows (in horizontall panels) or columns (in vertical panels) in tray widget</_short>
+		<default>1</default>
+		<min>1</min>
 	</option>
 	<option name="tray_menu_on_middle_click" type="bool">
 		<_short>Middle Button Activates Menu</_short>

--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -155,7 +155,7 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<min>0</min>
 	</option>
 	<option name="launchers_rows_cols" type="int">
-		<_short>Number of rows (in horizontall panels) or columns (in vertical panels) in Launchers widget</_short>
+		<_short>Number of rows (in horizontal panels) or columns (in vertical panels) in Launchers widget</_short>
 		<default>1</default>
 		<min>1</min>
 	</option>
@@ -566,7 +566,7 @@ If full_span is off, both sides of the panel will take the same amount of space,
 		<min>0</min>
 	</option>
 	<option name="tray_rows_cols" type="int">
-		<_short>Number of rows (in horizontall panels) or columns (in vertical panels) in tray widget</_short>
+		<_short>Number of rows (in horizontal panels) or columns (in vertical panels) in tray widget</_short>
 		<default>1</default>
 		<min>1</min>
 	</option>

--- a/src/panel/widgets/launchers.cpp
+++ b/src/panel/widgets/launchers.cpp
@@ -171,16 +171,20 @@ void WayfireLaunchers::init(Gtk::Box *container)
 
 void WayfireLaunchers::update_layout()
 {
-    box.set_spacing(spacing);
+    box.set_column_spacing(spacing);
+    box.set_row_spacing(spacing);
+    box.set_max_children_per_line(rows_cols);
+    box.set_min_children_per_line(rows_cols);
+    box.set_selection_mode(Gtk::SelectionMode::NONE);
 
     WfOption<std::string> panel_position{"panel/position"};
 
     if (panel_position.value() == PANEL_POSITION_LEFT or panel_position.value() == PANEL_POSITION_RIGHT)
     {
-        box.set_orientation(Gtk::Orientation::VERTICAL);
+        box.set_orientation(Gtk::Orientation::HORIZONTAL);
     } else
     {
-        box.set_orientation(Gtk::Orientation::HORIZONTAL);
+        box.set_orientation(Gtk::Orientation::VERTICAL);
     }
 }
 

--- a/src/panel/widgets/launchers.hpp
+++ b/src/panel/widgets/launchers.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include <giomm/desktopappinfo.h>
 #include <gtkmm/image.h>
-#include <gtkmm/box.h>
+#include <gtkmm/flowbox.h>
 #include <gtkmm/button.h>
 #include <wayfire/util/duration.hpp>
 
@@ -27,11 +27,12 @@ struct WfLauncherButton
 using launcher_container = std::vector<std::unique_ptr<WfLauncherButton>>;
 class WayfireLaunchers : public WayfireWidget
 {
-    Gtk::Box box;
+    Gtk::FlowBox box;
     launcher_container launchers;
     launcher_container get_launchers_from_config();
 
     WfOption<int> spacing{"panel/launchers_spacing"};
+    WfOption<int> rows_cols{"panel/launchers_rows_cols"};
 
   public:
     virtual void init(Gtk::Box *container);

--- a/src/panel/widgets/tray/item.cpp
+++ b/src/panel/widgets/tray/item.cpp
@@ -78,6 +78,7 @@ void StatusNotifierItem::init_widget()
     setup_tooltip();
     init_menu();
     icon.add_css_class("widget-icon");
+    icon.add_css_class("tray-button");
     add_css_class("tray-button");
 
     auto scroll_gesture = Gtk::EventControllerScroll::create();

--- a/src/panel/widgets/tray/tray.cpp
+++ b/src/panel/widgets/tray/tray.cpp
@@ -35,16 +35,20 @@ void WayfireStatusNotifier::remove_item(const Glib::ustring & service)
 
 void WayfireStatusNotifier::update_layout()
 {
-    icons_box.set_spacing(spacing);
+    icons_box.set_column_spacing(spacing);
+    icons_box.set_row_spacing(spacing);
+    icons_box.set_max_children_per_line(rows_cols);
+    icons_box.set_min_children_per_line(rows_cols);
+    icons_box.set_selection_mode(Gtk::SelectionMode::NONE);
 
     WfOption<std::string> panel_position{"panel/position"};
 
     if ((panel_position.value() == PANEL_POSITION_LEFT) || (panel_position.value() == PANEL_POSITION_RIGHT))
     {
-        icons_box.set_orientation(Gtk::Orientation::VERTICAL);
+        icons_box.set_orientation(Gtk::Orientation::HORIZONTAL);
     } else
     {
-        icons_box.set_orientation(Gtk::Orientation::HORIZONTAL);
+        icons_box.set_orientation(Gtk::Orientation::VERTICAL);
     }
 }
 

--- a/src/panel/widgets/tray/tray.hpp
+++ b/src/panel/widgets/tray/tray.hpp
@@ -11,10 +11,11 @@ class WayfireStatusNotifier : public WayfireWidget
   private:
     StatusNotifierHost host = StatusNotifierHost(this);
 
-    Gtk::Box icons_box;
+    Gtk::FlowBox icons_box;
     std::map<Glib::ustring, StatusNotifierItem> items;
 
     WfOption<int> spacing{"panel/tray_spacing"};
+    WfOption<int> rows_cols{"panel/tray_rows_cols"};
 
     void update_layout();
     void handle_config_reload();


### PR DESCRIPTION
* use FlowBox instead of Box in tray and launchers widgets to allow configure multi row panel
* fixed respecting `tray_icon_size` setting - add css class directly to icon