### PR TITLE
refresh command-output icons

### DIFF
--- a/src/panel/widgets/command-output.cpp
+++ b/src/panel/widgets/command-output.cpp
@@ -14,7 +14,7 @@
 #include "command-output.hpp"
 
 static sigc::connection label_set_from_command(std::string command_line,
-    Gtk::Label& label, Gtk::Image* icon = nullptr,
+    Gtk::Label& label, Gtk::Image *icon = nullptr,
     const std::string& icon_name = "")
 {
     command_line = "/bin/sh -c \"" + command_line + "\"";
@@ -47,12 +47,12 @@ static sigc::connection label_set_from_command(std::string command_line,
         label.set_markup(output);
 
         if (icon &&
-    	    !icon_name.empty() &&
-    	    (icon_name[0] == '/' ||
-     	     icon_name.rfind("~/", 0) == 0))
-	{
-    	    IconProvider::image_set_icon(*icon, icon_name);
-	}
+            !icon_name.empty() &&
+            ((icon_name[0] == '/') ||
+             (icon_name.rfind("~/", 0) == 0)))
+        {
+            IconProvider::image_set_icon(*icon, icon_name);
+        }
     }, pid);
 }
 

--- a/src/panel/widgets/command-output.cpp
+++ b/src/panel/widgets/command-output.cpp
@@ -14,7 +14,8 @@
 #include "command-output.hpp"
 
 static sigc::connection label_set_from_command(std::string command_line,
-    Gtk::Label& label)
+    Gtk::Label& label, Gtk::Image* icon = nullptr,
+    const std::string& icon_name = "")
 {
     command_line = "/bin/sh -c \"" + command_line + "\"";
 
@@ -23,6 +24,7 @@ static sigc::connection label_set_from_command(std::string command_line,
     Glib::spawn_async_with_pipes("", Glib::shell_parse_argv(command_line),
         Glib::SpawnFlags::DO_NOT_REAP_CHILD | Glib::SpawnFlags::SEARCH_PATH_FROM_ENVP,
         Glib::SlotSpawnChildSetup{}, &pid, nullptr, &output_fd, nullptr);
+
     return Glib::signal_child_watch().connect([=, &label] (Glib::Pid pid, int exit_status)
     {
         FILE *file = fdopen(output_fd, "r");
@@ -43,6 +45,14 @@ static sigc::connection label_set_from_command(std::string command_line,
         }
 
         label.set_markup(output);
+
+        if (icon &&
+    	    !icon_name.empty() &&
+    	    (icon_name[0] == '/' ||
+     	     icon_name.rfind("~/", 0) == 0))
+	{
+    	    IconProvider::image_set_icon(*icon, icon_name);
+	}
     }, pid);
 }
 
@@ -101,7 +111,7 @@ WfCommandOutputButtons::CommandOutput::CommandOutput(const std::string & name,
     const auto update_output = [=] ()
     {
         command_sig.disconnect();
-        command_sig = label_set_from_command(command, main_label);
+        command_sig = label_set_from_command(command, main_label, &icon, icon_name);
     };
 
     signals.push_back(signal_clicked().connect(update_output));


### PR DESCRIPTION
This PR adds support for dynamic command-output icons.

When the icon is specified as a filesystem path, it is reloaded after each command execution on the configured refresh interval. This allows icons for such such things as album art or weather icons to update automatically.

Icons specified by name (theme icons) continue to use the original static behavior and are not reloaded.