### PR TITLE
panel: fix occasional crash

### DIFF
--- a/src/panel/widgets/window-list/window-list.cpp
+++ b/src/panel/widgets/window-list/window-list.cpp
@@ -494,11 +494,13 @@ WayfireWindowList::~WayfireWindowList()
 
     if (this->manager)
     {
+        zwlr_foreign_toplevel_manager_v1_stop(this->manager);
         zwlr_foreign_toplevel_manager_v1_destroy(this->manager);
     }
 
     if (this->foreign_toplevel_list)
     {
+        ext_foreign_toplevel_list_v1_stop(this->foreign_toplevel_list);
         ext_foreign_toplevel_list_v1_destroy(this->foreign_toplevel_list);
     }
 


### PR DESCRIPTION
Bug report and fix in one, sorry

To reproduce crash:

get a program with an offending popup. I used xfce4-terminal's multi-line paste warning but also good were open/save as dialogs and almost all of android studio.

- Start wf-panel
- Add monitor
- Remove monitor
- cause popup

This would always cause a crash, but work fine if no hotplugging happened prior

The cause was leaked listeners continuing after the widget had deconstructed.