### PR TITLE
panel : default menu widgets to be centered horizontally and vertically

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -106,26 +106,25 @@ class WayfirePanel::impl
             right_box.measure(orientation, -1, rmin, rnat, rminb, rnatb);
             center_box.measure(orientation, -1, mmin, mnat, mminb, mnatb);
 
+            center_box.set_halign(Gtk::Align::CENTER);
+            center_box.set_valign(Gtk::Align::CENTER);
+
             if (is_horizontal)
             {
                 content_box.set_size_request((std::max(lnat, rnat) * 2) + mnat, -1);
 
                 left_box.set_halign(Gtk::Align::END);
                 right_box.set_halign(Gtk::Align::START);
-                center_box.set_halign(Gtk::Align::CENTER);
                 left_box.set_valign(Gtk::Align::FILL);
                 right_box.set_valign(Gtk::Align::FILL);
-                center_box.set_valign(Gtk::Align::FILL);
             } else
             {
                 content_box.set_size_request(-1, (std::max(lnat, rnat) * 2) + mnat);
 
                 left_box.set_halign(Gtk::Align::FILL);
                 right_box.set_halign(Gtk::Align::FILL);
-                center_box.set_halign(Gtk::Align::FILL);
                 left_box.set_valign(Gtk::Align::END);
                 right_box.set_valign(Gtk::Align::START);
-                center_box.set_valign(Gtk::Align::CENTER);
             }
         } else
         {

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -950,7 +950,7 @@ void WayfireWorkspaceSwitcher::grid_on_event(wf::json_t data)
 WayfireWorkspaceSwitcher::WayfireWorkspaceSwitcher(WayfireOutput *output)
 {
     this->output_name = output->monitor->get_connector();
-    switcher_box.set_vexpand(false);
+    switcher_box.set_halign(Gtk::Align::CENTER);
     switcher_box.set_valign(Gtk::Align::CENTER);
 }
 

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -187,6 +187,10 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     popover.add_css_class(class_name + "-popover");
     menu.add_css_class(class_name + "-popover");
 
+    // default alignment to being centered, as that’s the most common
+    set_halign(Gtk::Align::CENTER);
+    set_valign(Gtk::Align::CENTER);
+
     /* Scroller around widget popover for small screens */
     popover.set_child(scroll);
     scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);


### PR DESCRIPTION
This is at the moment the only kind of alignment that is wanted, and will probably remain so forever. Set the alignment once in wf-popover and let widgets handle themselves if they ever want somethig else, as well as their container box.

This fixes an issue with certain widgets not being horizontally centered when the panel is in a vertical layout (positioned left or right)