### PR TITLE
panel : menu : drop fullscreen menu feature

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -271,10 +271,6 @@ If full_span is off, both sides of the panel will take the same amount of space,
 	</group>
 	<group>
 	<_short>Menu</_short>
-	<option name="menu_fullscreen" type="bool">
-		<_short>Fullscreen Menu</_short>
-		<default>false</default>
-	</option>
 	<option name="menu_fuzzy_search" type="bool">
 		<_short>Use Fuzzy Search in Menu</_short>
 		<default>true</default>

--- a/src/panel/widgets/menu.cpp
+++ b/src/panel/widgets/menu.cpp
@@ -1078,13 +1078,6 @@ void WayfireMenu::init(Gtk::Box *container)
     }));
     box.add_controller(click_gesture);
 
-    auto menu_fs_changed = [=]
-    {
-        button->set_fullscreen(menu_fullscreen.value());
-    };
-    menu_fullscreen.set_callback(menu_fs_changed);
-    menu_fs_changed();
-
     logout_image.set_icon_size(Gtk::IconSize::LARGE);
     logout_image.set_from_icon_name("system-shutdown");
     logout_button.add_css_class("flat");

--- a/src/panel/widgets/menu.hpp
+++ b/src/panel/widgets/menu.hpp
@@ -202,7 +202,6 @@ class WayfireMenu : public WayfireWidget
     WfOption<int> menu_min_category_width{"panel/menu_min_category_width"};
     WfOption<int> menu_min_content_height{"panel/menu_min_content_height"};
     WfOption<bool> menu_show_categories{"panel/menu_show_categories"};
-    WfOption<bool> menu_fullscreen{"panel/menu_fullscreen"};
     void setup_popover_layout();
     void update_popover_layout();
     void update_size();

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -67,14 +67,8 @@ void WayfireMenuWidget::popup(bool autohide)
         menu.popup();
     } else if (use_widget)
     {
-        if (fullscreen)
-        {
-            fullscreen->show();
-        } else
-        {
-            popover.set_autohide(autohide);
-            popover.popup();
-        }
+        popover.set_autohide(autohide);
+        popover.popup();
     } else
     {
         return;
@@ -128,10 +122,6 @@ void WayfireMenuWidget::popdown()
     remove_css_class("selected");
     menu.popdown();
     popover.popdown();
-    if (fullscreen)
-    {
-        fullscreen->hide();
-    }
 
     popdown_signal.emit();
     panel->unset_active_popover();
@@ -347,43 +337,6 @@ bool WayfireMenuWidget::is_popup_visible()
     }
 
     return false;
-}
-
-void WayfireMenuWidget::set_fullscreen(bool fs)
-{
-    auto panel = get_panel(this);
-    if (!panel)
-    {
-        return;
-    }
-
-    if (fs && (fullscreen == nullptr))
-    {
-        gtk_popover_set_child(popover.gobj(), nullptr);
-
-        /* Prepare fullscreen layer */
-        fullscreen = std::make_shared<Gtk::Window>();
-        fullscreen->add_css_class(class_name + "-fullscreen-popover");
-        fullscreen->add_css_class(class_name + "-popover");
-        fullscreen->add_css_class("fullscreen-popover");
-        gtk_layer_init_for_window(fullscreen->gobj());
-        gtk_layer_set_namespace(fullscreen->gobj(), "panelmenu");
-        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_TOP, true);
-        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_BOTTOM, true);
-        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_LEFT, true);
-        gtk_layer_set_anchor(fullscreen->gobj(), GTK_LAYER_SHELL_EDGE_RIGHT, true);
-        gtk_layer_set_layer(fullscreen->gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-        gtk_layer_set_keyboard_mode(fullscreen->gobj(), GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
-        gtk_layer_set_monitor(fullscreen->gobj(), panel->get_output()->monitor->gobj());
-
-        fullscreen->set_child(scroll);
-    } else if (!fs && fullscreen)
-    {
-        gtk_window_set_child(fullscreen->gobj(), nullptr);
-        popover.set_child(scroll);
-        fullscreen->close();
-        fullscreen = nullptr;
-    }
 }
 
 void WayfireMenuWidget::cancel_timer()

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -103,5 +103,4 @@ class WayfireMenuWidget : public Gtk::Box
     /* Use a specific mouse button to open menu. Skip this if you're handling presses in-widget. If button < 0
      * then this callback is removed  */
     void open_on(int button);
-    void set_fullscreen(bool fs);
 };


### PR DESCRIPTION
It is currently broken, and @trigg mentionned they wanted to drop it/not maintain it. Of course, i’m not exactly looking to not have this feature, but with the release coming soon, either someone fixes it or we have to drop it.