### PR TITLE
panel: fix horizontal alignment in veritcal layout

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -106,26 +106,25 @@ class WayfirePanel::impl
             right_box.measure(orientation, -1, rmin, rnat, rminb, rnatb);
             center_box.measure(orientation, -1, mmin, mnat, mminb, mnatb);
 
+            center_box.set_halign(Gtk::Align::CENTER);
+            center_box.set_valign(Gtk::Align::CENTER);
+
             if (is_horizontal)
             {
                 content_box.set_size_request((std::max(lnat, rnat) * 2) + mnat, -1);
 
                 left_box.set_halign(Gtk::Align::END);
                 right_box.set_halign(Gtk::Align::START);
-                center_box.set_halign(Gtk::Align::CENTER);
                 left_box.set_valign(Gtk::Align::FILL);
                 right_box.set_valign(Gtk::Align::FILL);
-                center_box.set_valign(Gtk::Align::FILL);
             } else
             {
                 content_box.set_size_request(-1, (std::max(lnat, rnat) * 2) + mnat);
 
                 left_box.set_halign(Gtk::Align::FILL);
                 right_box.set_halign(Gtk::Align::FILL);
-                center_box.set_halign(Gtk::Align::FILL);
                 left_box.set_valign(Gtk::Align::END);
                 right_box.set_valign(Gtk::Align::START);
-                center_box.set_valign(Gtk::Align::CENTER);
             }
         } else
         {

--- a/src/panel/widgets/battery.cpp
+++ b/src/panel/widgets/battery.cpp
@@ -157,7 +157,7 @@ void WayfireBatteryInfo::update_details()
     {
         label.set_text(percentage_string);
         overlay.remove_overlay(label);
-        box->append(label);
+        box->set_child(label);
     } else if (status_opt.value() == BATTERY_STATUS_FULL)
     {
         label.set_text(description);
@@ -167,7 +167,7 @@ void WayfireBatteryInfo::update_details()
             overlay.remove_overlay(label);
         }
 
-        box->append(label);
+        box->set_child(label);
     } else if (status_opt.value() == BATTERY_STATUS_OVERLAY)
     {
         label.set_text(percentage_string);
@@ -313,7 +313,7 @@ void WayfireBatteryInfo::init(Gtk::Box *container)
 
     box = std::make_unique<WayfireMenuWidget>("panel", "battery");
 
-    box->append(overlay);
+    box->set_child(overlay);
     overlay.set_child(icon);
     icon.add_css_class("widget-icon");
 

--- a/src/panel/widgets/clock.cpp
+++ b/src/panel/widgets/clock.cpp
@@ -5,7 +5,7 @@ void WayfireClock::init(Gtk::Box *container)
 {
     button = std::make_unique<WayfireMenuWidget>("panel", "clock");
     button->add_css_class("clock");
-    button->append(label);
+    button->set_child(label);
     button->open_on(1);
     label.set_justify(Gtk::Justification::CENTER);
     label.show();

--- a/src/panel/widgets/menu/menu.cpp
+++ b/src/panel/widgets/menu/menu.cpp
@@ -476,7 +476,7 @@ void WayfireMenu::init(Gtk::Box *container)
     menu_list.set_callback([=] () { update_popover_layout(); });
 
     button = std::make_unique<WayfireMenuWidget>("panel", "menu");
-    button->append(main_image);
+    button->set_child(main_image);
     button->set_keyboard_interactive(true);
     button->add_css_class("menu-button");
     button->open_on(1); /* Open menu on left click */
@@ -495,18 +495,6 @@ void WayfireMenu::init(Gtk::Box *container)
 
     container->append(box);
     box.append(*button);
-
-    auto click_gesture = Gtk::GestureClick::create();
-    click_gesture->set_propagation_phase(Gtk::PropagationPhase::CAPTURE);
-    signals.push_back(click_gesture->signal_pressed().connect([=] (int count, double x, double y)
-    {
-        click_gesture->set_state(Gtk::EventSequenceState::CLAIMED);
-    }));
-    signals.push_back(click_gesture->signal_released().connect([=] (int count, double x, double y)
-    {
-        toggle_menu();
-    }));
-    box.add_controller(click_gesture);
 
     logout_image.set_icon_size(Gtk::IconSize::LARGE);
     logout_image.set_from_icon_name("system-shutdown");

--- a/src/panel/widgets/mixer/mixer.cpp
+++ b/src/panel/widgets/mixer/mixer.cpp
@@ -173,7 +173,7 @@ void WayfireMixer::init(Gtk::Box *container)
     // sets up the "widget part"
 
     button = std::make_unique<WayfireMenuWidget>("panel", "mixer");
-    button->append(main_image);
+    button->set_child(main_image);
     button->show();
     button->open_on(-1); // the gestures callback will take care of opening and closing
     sinks_box.add_css_class("outputs");

--- a/src/panel/widgets/network.cpp
+++ b/src/panel/widgets/network.cpp
@@ -19,7 +19,7 @@ void WayfireNetworkInfo::init(Gtk::Box *container)
     button->add_css_class("network");
 
     container->append(*button);
-    button->append(button_content);
+    button->set_child(button_content);
 
     button->set_popup_child(control);
 

--- a/src/panel/widgets/notifications/notification-center.cpp
+++ b/src/panel/widgets/notifications/notification-center.cpp
@@ -16,7 +16,7 @@ void WayfireNotificationCenter::init(Gtk::Box *container)
     button->get_children()[0]->add_css_class("flat");
 
     updateIcon();
-    button->append(icon);
+    button->set_child(icon);
     button->open_on(1);
     container->append(*button);
 

--- a/src/panel/widgets/tray/item.cpp
+++ b/src/panel/widgets/tray/item.cpp
@@ -55,7 +55,7 @@ StatusNotifierItem::StatusNotifierItem(const Glib::ustring & service) :
         "tray-button",
         "tray_button")
 {
-    append(icon);
+    set_child(icon);
     menu = std::make_shared<DbusMenuModel>();
 
     const auto & [name, path] = name_and_obj_path(service);

--- a/src/panel/widgets/volume.cpp
+++ b/src/panel/widgets/volume.cpp
@@ -205,7 +205,7 @@ void WayfireVolume::init(Gtk::Box *container)
 
     /* Setup layout */
     container->append(*button);
-    button->append(main_image);
+    button->set_child(main_image);
     button->set_popup_child(volume_scale);
     /* Override scroll bar as it isn't needed here */
     button->get_scroll().set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::NEVER);

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -53,7 +53,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
         } else // "grid_popover"
         {
             button->set_popup_child(overlay);
-            button->append(mini_grid);
+            button->set_child(mini_grid);
             switcher_box.append(*button);
             button->open_on(1);
         }

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -950,7 +950,7 @@ void WayfireWorkspaceSwitcher::grid_on_event(wf::json_t data)
 WayfireWorkspaceSwitcher::WayfireWorkspaceSwitcher(WayfireOutput *output)
 {
     this->output_name = output->monitor->get_connector();
-    switcher_box.set_vexpand(false);
+    switcher_box.set_halign(Gtk::Align::CENTER);
     switcher_box.set_valign(Gtk::Align::CENTER);
 }
 

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -21,7 +21,11 @@ WayfireAutohidingWindow *get_panel(Gtk::Widget *button)
 
 void WayfireMenuWidget::set_child(Gtk::Widget & widget)
 {
-    append(widget);
+    Gtk::Box::append(widget);
+    widget.set_valign(Gtk::Align::CENTER);
+    widget.set_halign(Gtk::Align::CENTER);
+    widget.set_hexpand(true);
+    widget.set_vexpand(true);
 }
 
 void WayfireMenuWidget::set_no_child()
@@ -178,8 +182,10 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     menu.add_css_class(class_name + "-popover");
 
     // default alignment to being centered, as that’s the most common
-    set_halign(Gtk::Align::CENTER);
-    set_valign(Gtk::Align::CENTER);
+    set_halign(Gtk::Align::FILL);
+    set_valign(Gtk::Align::FILL);
+    set_hexpand(true);
+    set_vexpand(true);
 
     /* Scroller around widget popover for small screens */
     popover.set_child(scroll);

--- a/src/util/wf-popover.cpp
+++ b/src/util/wf-popover.cpp
@@ -177,6 +177,10 @@ WayfireMenuWidget::WayfireMenuWidget(const std::string& section, const std::stri
     popover.add_css_class(class_name + "-popover");
     menu.add_css_class(class_name + "-popover");
 
+    // default alignment to being centered, as that’s the most common
+    set_halign(Gtk::Align::CENTER);
+    set_valign(Gtk::Align::CENTER);
+
     /* Scroller around widget popover for small screens */
     popover.set_child(scroll);
     scroll.set_policy(Gtk::PolicyType::AUTOMATIC, Gtk::PolicyType::AUTOMATIC);

--- a/src/util/wf-popover.hpp
+++ b/src/util/wf-popover.hpp
@@ -46,6 +46,11 @@ class WayfireMenuWidget : public Gtk::Box
 
   public:
 
+    void append(Gtk::Widget& child)  = delete;
+    void prepend(Gtk::Widget& child) = delete;
+    void insert_child_after(Gtk::Widget& child, Gtk::Widget& sibling) = delete;
+
+    void add_button(Gtk::Widget&);
     void set_no_child();
     void set_menu_model(Glib::RefPtr<Gio::MenuModel> menu);
     void set_child(Gtk::Widget & widget);


### PR DESCRIPTION
Based on @AKArien 's suggestion, but pushing the idea out a bit further to make the concept more central. 

Hide WfMenuWidget's `append` and similar direct access functions and formalise on `set_child` for the on-panel widget and either `set_popup_child` or `set_menu_model` for the popup contents, if any.

The only widget not playing nice, in my experience, with vertical layouts is window-list. This is the case before and after this PR.

Replaces #510 (sorry)