### PR TITLE
panel : switcher : fix broken row mode

### DIFF
--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -423,8 +423,8 @@ void WayfireWorkspaceSwitcher::process_workspaces(wf::json_t workspace_data)
             if (this->output_name == output_data["name"].as_string())
             {
                 auto output_id     = output_data["id"].as_int();
-                auto output_width  = output_data["geometry"]["width"].as_int();
-                auto output_height = output_data["geometry"]["height"].as_int();
+                this->output_width = output_data["geometry"]["width"].as_int();
+                this->output_height = output_data["geometry"]["height"].as_int();
                 for (auto w : windows)
                 {
                     if (w->active)


### PR DESCRIPTION
The row mode was unable to work good because the output dimensions were never actually set, just declaring a local variable instead of setting the member.