### PR TITLE
panel : window-list/workspace-switcher : renamed options

### DIFF
--- a/metadata/panel.xml
+++ b/metadata/panel.xml
@@ -659,7 +659,7 @@ Set to -1 to only run it by clicking the button.
 		<default>16</default>
 		<min>1</min>
 	</option>
-	<option name="live_window_previews" type="bool">
+	<option name="window_list_live_window_previews" type="bool">
 		<_short>Live Window Previews</_short>
 		<_long>Enable live window previews when hovering over application buttons in the window list instead of the title tooltip.</_long>
 		<default>false</default>
@@ -667,8 +667,8 @@ Set to -1 to only run it by clicking the button.
 	</group>
 	<group>
 	<_short>Workspace Switcher</_short>
-	<option name="workspace_switcher_mode" type="string">
-		<_short>Workspace switcher widget mode</_short>
+	<option name="workspace_switcher_layout" type="string">
+		<_short>Workspace switcher widget layout</_short>
 		<desc>
 			<value>row</value>
 			<_name>Current row</_name>

--- a/src/panel/widgets/window-list/window-list.hpp
+++ b/src/panel/widgets/window-list/window-list.hpp
@@ -84,7 +84,7 @@ class WayfireWindowList : public Gtk::Box, public WayfireWidget
      */
     Gtk::Widget *get_widget_before(int x);
 
-    WfOption<bool> live_window_previews{"panel/live_window_previews"};
+    WfOption<bool> live_window_previews{"panel/window_list_live_window_previews"};
     void handle_new_wl_output(wl_output *output);
 
     zwp_linux_dmabuf_feedback_v1 *feedback = nullptr;

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -42,11 +42,11 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
             overlay.unparent();
         }
 
-        if (workspace_switcher_mode.value() == "row")
+        if (layout.value() == "row")
         {
             switcher_box.append(box);
             button->open_on(-1);
-        } else if (workspace_switcher_mode.value() == "grid")
+        } else if (layout.value() == "grid")
         {
             switcher_box.append(overlay);
             button->open_on(-1);
@@ -60,7 +60,7 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
 
         get_wsets();
     });
-    workspace_switcher_mode.set_callback(mode_cb);
+    layout.set_callback(mode_cb);
 
     workspace_switcher_render_views.set_callback([=] ()
     {
@@ -81,14 +81,14 @@ void WayfireWorkspaceSwitcher::set_size()
         val = (double)WfOption<int>{"panel/minimal_height"}.value();
     }
 
-    if (workspace_switcher_mode.value() == "row")
+    if (layout.value() == "row")
     {
         WfOption<std::string> panel_position{"panel/position"};
         if (panel_position.value() == PANEL_POSITION_LEFT or panel_position.value() == PANEL_POSITION_RIGHT)
         {
             val = val / grid_width;
         }
-    } else if (workspace_switcher_mode.value() == "grid")
+    } else if (layout.value() == "grid")
     {
         val = val / grid_height;
     }
@@ -107,7 +107,7 @@ void WayfireWorkspaceSwitcher::get_wsets()
             return;
         }
 
-        if (workspace_switcher_mode.value() == "row")
+        if (layout.value() == "row")
         {
             process_workspaces(data);
         } else // "grid"/"grid_popover"
@@ -783,7 +783,7 @@ void WayfireWorkspaceSwitcher::grid_render_views(wf::json_t views_data)
 
 void WayfireWorkspaceSwitcher::on_event(wf::json_t data)
 {
-    if (workspace_switcher_mode.value() == "row")
+    if (layout.value() == "row")
     {
         switcher_on_event(data);
     } else // "grid"/"grid_popover"

--- a/src/panel/widgets/workspace-switcher.hpp
+++ b/src/panel/widgets/workspace-switcher.hpp
@@ -63,7 +63,7 @@ class WayfireWorkspaceSwitcher : public WayfireWidget, public IIPCSubscriber
     std::pair<int, int> grid_get_workspace(WayfireWorkspaceWindow *w);
     int current_ws_x, current_ws_y;
     std::vector<WayfireWorkspaceWindow*> windows;
-    WfOption<std::string> workspace_switcher_mode{"panel/workspace_switcher_mode"};
+    WfOption<std::string> layout{"panel/workspace_switcher_layout"};
     WfOption<double> workspace_switcher_target_size_opt{"panel/workspace_switcher_target_size"};
     double workspace_switcher_target_size;
     WfOption<bool> workspace_switcher_render_views{"panel/workspace_switcher_render_views"};


### PR DESCRIPTION
Rename live_window_previews to window_list_live_window_previews and workspace_switcher_mode to workspace_switcher_layout for consistency and clarity