### PR TITLE
Let auto widget size (0) take the panel’s relevant dimension

### DIFF
--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -600,7 +600,6 @@ void WayfirePanelApp::on_activate()
 
     const static std::vector<std::pair<std::string, std::string>> icon_sizes_args =
     {
-        {"panel/minimal_height", ".widget-icon"},
         {"panel/default_icon_size", ".default-icon"},
         {"panel/menu_icon_size", ".menu-icon.widget-icon"},
         {"panel/menu_item_icon_size", ".app-button .default-icon"},
@@ -620,6 +619,8 @@ void WayfirePanelApp::on_activate()
     {
         new CssFromConfigIconSize(pair.first, pair.second);
     }
+
+    new CssFromConfigEdge("panel/position", "panel/minimal_height", "panel/minimal_width");
 
     new CssFromConfigInt("panel/launchers_spacing", ".launcher{padding: 0px ", "px;}");
     new CssFromConfigString("panel/background_color", ".wf-panel{background-color:", ";}");

--- a/src/panel/widgets/window-list/toplevel.cpp
+++ b/src/panel/widgets/window-list/toplevel.cpp
@@ -700,7 +700,10 @@ class WayfireToplevel::impl
 
     void set_app_id(std::string app_id)
     {
+        // for now, the widget pretty much doesn’t work for vertical panels,
+        // but when the widget is made to work vertically this will need to change
         WfOption<int> minimal_panel_height{"panel/minimal_height"};
+
         this->app_id = app_id;
         IconProvider::image_set_icon(image, app_id);
         this->view_id = this->window_list->get_view_id_from_full_app_id(app_id);

--- a/src/panel/widgets/workspace-switcher.cpp
+++ b/src/panel/widgets/workspace-switcher.cpp
@@ -76,21 +76,34 @@ void WayfireWorkspaceSwitcher::init(Gtk::Box *container)
 void WayfireWorkspaceSwitcher::set_size()
 {
     double val = workspace_switcher_target_size_opt.value();
+    WfOption<std::string> panel_position{"panel/position"};
+
     if (val == 0.0)
     {
-        val = (double)WfOption<int>{"panel/minimal_height"}.value();
+        if (panel_position.value() == PANEL_POSITION_LEFT or panel_position.value() == PANEL_POSITION_RIGHT)
+        {
+            val = (double)WfOption<int>{"panel/minimal_width"}.value();
+        } else
+        {
+            val = (double)WfOption<int>{"panel/minimal_height"}.value();
+        }
     }
 
     if (layout.value() == "row")
     {
-        WfOption<std::string> panel_position{"panel/position"};
         if (panel_position.value() == PANEL_POSITION_LEFT or panel_position.value() == PANEL_POSITION_RIGHT)
         {
             val = val / grid_width;
         }
     } else if (layout.value() == "grid")
     {
-        val = val / grid_height;
+        if (panel_position.value() == PANEL_POSITION_TOP or panel_position.value() == PANEL_POSITION_BOTTOM)
+        {
+            val = val / grid_height;
+        } else
+        {
+            val = val / grid_width;
+        }
     }
 
     workspace_switcher_target_size = val;

--- a/src/util/css-config.cpp
+++ b/src/util/css-config.cpp
@@ -1,4 +1,5 @@
 #include <css-config.hpp>
+#include <cstdlib>
 #include <sstream>
 #include <iostream>
 #include <regex>
@@ -159,4 +160,32 @@ void CssFromConfigFont::set_from_string()
         provider->load_from_string(css);
         std::cout << "Font fallback " << css << std::endl;
     }
+}
+
+CssFromConfigEdge::CssFromConfigEdge(std::string config_opt, std::string height_opt, std::string width_opt) :
+    option_value{config_opt},
+    height_value{height_opt},
+    width_value(width_opt)
+{
+    provider = Gtk::CssProvider::create();
+
+    auto callback = [=] ()
+    {
+        std::stringstream ss;
+        auto position = option_value.value();
+        if ((position == "top") || (position == "bottom"))
+        {
+            ss << ".wf-panel .widget-icon {-gtk-icon-size:" << height_value.value() << "px;}";
+        } else
+        {
+            ss << ".wf-panel .widget-icon {-gtk-icon-size:" << width_value.value() << "px;}";
+        }
+
+        provider->load_from_string(ss.str());
+    };
+    option_value.set_callback(callback);
+    height_value.set_callback(callback);
+    width_value.set_callback(callback);
+    callback();
+    add_provider();
 }

--- a/src/util/css-config.hpp
+++ b/src/util/css-config.hpp
@@ -63,3 +63,12 @@ class CssFromConfigInt : public CssFromConfig
   public:
     CssFromConfigInt(std::string config_opt, std::string css_before, std::string css_after);
 };
+
+class CssFromConfigEdge : public CssFromConfig
+{
+    WfOption<std::string> option_value;
+    WfOption<int> height_value, width_value;
+
+  public:
+    CssFromConfigEdge(std::string config_opt, std::string height_opt, std::string width_opt);
+};


### PR DESCRIPTION
currently, when an icon has a size of 0, it gets applied the panel’s minimal height as it’s size

for consistency, it’d be better if it could be the minimal width when the panel is on the left or right

