### PR TITLE
Use more common icon name for wf-locker-pin

### DIFF
--- a/data/wf-locker-pin.desktop
+++ b/data/wf-locker-pin.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Exec=wf-locker-pin
-Icon=lock-symbolic
+Icon=system-lock-screen
 Terminal=false
 Name=Wf Shell Change PIN
 Categories=Utility;Settings;DesktopSettings;


### PR DESCRIPTION
The `lock-symbolic` cannot be found in the Adwaita theme. Use `system-lock-screen-symbolic` instead.