### PR TITLE
locker: fix Clang build failure in switch on WfOption<int>

### DIFF
--- a/src/locker/timedrevealer.cpp
+++ b/src/locker/timedrevealer.cpp
@@ -18,7 +18,7 @@ WayfireLockerTimedRevealer::WayfireLockerTimedRevealer(std::string always_option
     auto hide_callback = [this] ()
     {
         Gtk::RevealerTransitionType type = Gtk::RevealerTransitionType::NONE;
-        switch (hide_animation)
+        switch (hide_animation.value())
         {
           case 1:
             type = Gtk::RevealerTransitionType::CROSSFADE;


### PR DESCRIPTION
Clang rejects the implicit decltype(auto) conversion operator from base_option_wrapper_t as a valid contextual conversion for switch, while GCC accepts it. Use the explicit .value() accessor instead. The root cause I found was wf-config [PR #86](https://github.com/WayfireWM/wf-config/pull/86) ('Don't copy accessed values in getters", merged Nov 14 2025, commit 3597fcd), which changed the getter/conversion-operator return type to a decltype(auto) from a fixed type. This change pulled in WF_LIFETIMEBOUND and made the implicit conversion operator return a deduced type instead of a fixed one. Clang does not accept a decltype(auto)-typed conversion operator as a valid contextual conversion for switch, while GCC does, the maintainers probably didn't test this for clang and shipped it. The wf-config maintainer's review comment on [#86 ](https://github.com/WayfireWM/wf-config/pull/86) ("btw when updating wayfire we should also bump the api/abi version there ..") correctly recognised that this was a breaking change but they did not test this against clang. I presume I was the first person to compile it against clang and encountered this error while compiling for chimera linux cports repo. Since this is a one line change I hope it will be quick merged.